### PR TITLE
Add Explicit Sync/Async clients, and add mypy types for the library

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Lint"
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   push:
     branches:
       - "main"
@@ -74,4 +74,25 @@ jobs:
       - name: "Upload Trivy scan results to GitHub Security tab"
         uses: "github/codeql-action/upload-sarif@v3"
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results.sarif"
+  mypy:
+    name: "Type Check with Mypy"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.10"
+      - name: "Setup Python Environment"
+        run: "pip install -U pip virtualenv"
+      - name: "Install Dependencies"
+        run: |
+          virtualenv ~/.cache/virtualenv/authzedpy
+          source ~/.cache/virtualenv/authzedpy/bin/activate
+          pip install poetry
+          poetry env info
+          poetry install --only dev
+      - name: mypy
+        run: |
+          source ~/.cache/virtualenv/authzedpy/bin/activate
+          mypy authzed

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -92,7 +92,7 @@ jobs:
           pip install poetry
           poetry env info
           poetry install --only dev
-      - name: mypy
+      - name: "mypy"
         run: |
           source ~/.cache/virtualenv/authzedpy/bin/activate
           mypy authzed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,6 +74,6 @@ jobs:
           whereis protoc-gen-mypy
           whereis protoc-gen-mypy_grpc
           echo $GITHUB_PATH
-        uses: "bufbuild/buf-setup-action@v1.30.1"
+      - uses: "bufbuild/buf-setup-action@v1.30.1"
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,3 +112,15 @@ You can regenerate the code by executing `buf.gen.yaml`:
 1. `poetry install --with dev`
 1. `docker run -d -p 50051:50051 -p 50052:50052 --entrypoint spicedb quay.io/authzed/spicedb:latest-debug serve-testing` (or pick a specific version of the spicedb server as appropriate)
 1. `poetry run pytest -vv .`
+
+### Passing the linters
+
+See the [lint workflow](/.github/workflows/lint.yaml) for updated steps, but it should look something like this:
+
+```sh
+poetry install --with dev
+poetry shell
+find . -name "*.py" | grep -v "_pb2" | xargs pyflakes
+black .
+find . -name "*.py" | grep -v "_pb2" | xargs isort
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,3 +106,9 @@ You can regenerate the code by executing `buf.gen.yaml`:
 ```sh
 ./buf.gen.yaml
 ```
+
+### Running the Unit tests
+
+1. `poetry install --with dev`
+1. `docker run -d -p 50051:50051 -p 50052:50052 --entrypoint spicedb quay.io/authzed/spicedb:latest-debug serve-testing` (or pick a specific version of the spicedb server as appropriate)
+1. `poetry run pytest -vv .`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![Build Status](https://github.com/authzed/authzed-py/workflows/Test/badge.svg)](https://github.com/authzed/authzed-py/actions)
 [![Mailing List](https://img.shields.io/badge/email-google%20groups-4285F4)](https://groups.google.com/g/authzed-oss)
-[![Discord Server](https://img.shields.io/discord/844600078504951838?color=7289da&logo=discord "Discord Server")](https://discord.gg/jTysUaxXzM)
+[![Discord Server](https://img.shields.io/discord/844600078504951838?color=7289da&logo=discord 'Discord Server')](https://discord.gg/jTysUaxXzM)
 [![Twitter](https://img.shields.io/twitter/follow/authzed?color=%23179CF0&logo=twitter&style=flat-square)](https://twitter.com/authzed)
 
 This repository houses the Python client library for Authzed.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![Build Status](https://github.com/authzed/authzed-py/workflows/Test/badge.svg)](https://github.com/authzed/authzed-py/actions)
 [![Mailing List](https://img.shields.io/badge/email-google%20groups-4285F4)](https://groups.google.com/g/authzed-oss)
-[![Discord Server](https://img.shields.io/discord/844600078504951838?color=7289da&logo=discord 'Discord Server')](https://discord.gg/jTysUaxXzM)
+[![Discord Server](https://img.shields.io/discord/844600078504951838?color=7289da&logo=discord "Discord Server")](https://discord.gg/jTysUaxXzM)
 [![Twitter](https://img.shields.io/twitter/follow/authzed?color=%23179CF0&logo=twitter&style=flat-square)](https://twitter.com/authzed)
 
 This repository houses the Python client library for Authzed.

--- a/authzed/api/v1/__init__.py
+++ b/authzed/api/v1/__init__.py
@@ -61,7 +61,7 @@ from authzed.api.v1.watch_service_pb2_grpc import WatchServiceStub
 
 class Client(SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub, WatchServiceStub):
     """
-    v1 Authzed gRPC API client.
+    v1 Authzed gRPC API client - Auto-detects sync or async depending on if initialized within an event loop
     """
 
     def __init__(self, target, credentials, options=None, compression=None):
@@ -72,6 +72,36 @@ class Client(SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub,
             channelfn = grpc.secure_channel
 
         channel = channelfn(target, credentials, options, compression)
+        SchemaServiceStub.__init__(self, channel)
+        PermissionsServiceStub.__init__(self, channel)
+        ExperimentalServiceStub.__init__(self, channel)
+        WatchServiceStub.__init__(self, channel)
+
+
+class AsyncClient(
+    SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub, WatchServiceStub
+):
+    """
+    v1 Authzed gRPC API client, for use with asyncio.
+    """
+
+    def __init__(self, target, credentials, options=None, compression=None):
+        channel = grpc.aio.secure_channel(target, credentials, options, compression)
+        SchemaServiceStub.__init__(self, channel)
+        PermissionsServiceStub.__init__(self, channel)
+        ExperimentalServiceStub.__init__(self, channel)
+        WatchServiceStub.__init__(self, channel)
+
+
+class SyncClient(
+    SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub, WatchServiceStub
+):
+    """
+    v1 Authzed gRPC API client, running synchronously.
+    """
+
+    def __init__(self, target, credentials, options=None, compression=None):
+        channel = grpc.secure_channel(target, credentials, options, compression)
         SchemaServiceStub.__init__(self, channel)
         PermissionsServiceStub.__init__(self, channel)
         ExperimentalServiceStub.__init__(self, channel)

--- a/authzed/api/v1/__init__.pyi
+++ b/authzed/api/v1/__init__.pyi
@@ -1,0 +1,37 @@
+from authzed.api.v1.schema_service_pb2_grpc import SchemaServiceStub, SchemaServiceAsyncStub
+from authzed.api.v1.experimental_service_pb2_grpc import (
+    ExperimentalServiceStub,
+    ExperimentalServiceAsyncStub,
+)
+from authzed.api.v1.permission_service_pb2_grpc import (
+    PermissionsServiceStub,
+    PermissionsServiceAsyncStub,
+)
+from authzed.api.v1.watch_service_pb2_grpc import WatchServiceStub, WatchServiceAsyncStub
+import grpc
+from typing import Optional, Sequence, Tuple, Any
+
+class SyncClient(
+    SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub, WatchServiceStub
+):
+    def __init__(
+        self,
+        target: str,
+        credentials: grpc.ChannelCredentials,
+        options: Optional[Sequence[Tuple[str, Any]]] = None,
+        compression: Optional[grpc.Compression] = None,
+    ) -> None: ...
+
+class AsyncClient(
+    SchemaServiceAsyncStub,
+    PermissionsServiceAsyncStub,
+    ExperimentalServiceAsyncStub,
+    WatchServiceAsyncStub,
+):
+    def __init__(
+        self,
+        target: str,
+        credentials: grpc.ChannelCredentials,
+        options: Optional[Sequence[Tuple[str, Any]]] = None,
+        compression: Optional[grpc.Compression] = None,
+    ) -> None: ...

--- a/authzed/api/v1/__init__.pyi
+++ b/authzed/api/v1/__init__.pyi
@@ -11,6 +11,19 @@ from authzed.api.v1.watch_service_pb2_grpc import WatchServiceStub, WatchService
 import grpc
 from typing import Optional, Sequence, Tuple, Any
 
+class Client(SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub, WatchServiceStub):
+    """The Client is typed as a synchronous client (though in practice it works with both sync and async code).
+    If you are using the async code, you should switch to the AsyncClient class instead in order to get proper type hints
+    """
+
+    def __init__(
+        self,
+        target: str,
+        credentials: grpc.ChannelCredentials,
+        options: Optional[Sequence[Tuple[str, Any]]] = None,
+        compression: Optional[grpc.Compression] = None,
+    ) -> None: ...
+
 class SyncClient(
     SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub, WatchServiceStub
 ):

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "appier"
-version = "1.32.0"
+version = "1.33.0"
 description = "Appier Framework"
 optional = false
 python-versions = "*"
 files = [
-    {file = "appier-1.32.0-py2.py3-none-any.whl", hash = "sha256:6c2a1f717f207f11d4593c558c61ec8d30b205019e82a796074cd52cfa394f1e"},
-    {file = "appier-1.32.0.tar.gz", hash = "sha256:9a77ae2eea72c87fc9034cc95cbf696345094699343f160f1a82d52a070c0d5f"},
+    {file = "appier-1.33.0-py2.py3-none-any.whl", hash = "sha256:32a8452f139188700bf4745d199986dd5215af15188d880fb0bda7bcf9cc3494"},
+    {file = "appier-1.33.0.tar.gz", hash = "sha256:73dcbf672f0152944b7970f10e9be1249623addcd83d839879722bae134fb523"},
 ]
 
 [[package]]
@@ -271,13 +271,13 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-auth"
-version = "2.28.2"
+version = "2.29.0"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-auth-2.28.2.tar.gz", hash = "sha256:80b8b4969aa9ed5938c7828308f20f035bc79f9d8fb8120bf9dc8db20b41ba30"},
-    {file = "google_auth-2.28.2-py2.py3-none-any.whl", hash = "sha256:9fd67bbcd40f16d9d42f950228e9cf02a2ded4ae49198b27432d0cded5a74c38"},
+    {file = "google-auth-2.29.0.tar.gz", hash = "sha256:672dff332d073227550ffc7457868ac4218d6c500b155fe6cc17d2b13602c360"},
+    {file = "google_auth-2.29.0-py2.py3-none-any.whl", hash = "sha256:d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415"},
 ]
 
 [package.dependencies]
@@ -308,6 +308,20 @@ protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.1 || >4.21.1,<4
 
 [package.extras]
 grpc = ["grpcio (>=1.44.0,<2.0.0.dev0)"]
+
+[[package]]
+name = "grpc-stubs"
+version = "1.53.0.5"
+description = "Mypy stubs for gRPC"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "grpc-stubs-1.53.0.5.tar.gz", hash = "sha256:3e1b642775cbc3e0c6332cfcedfccb022176db87e518757bef3a1241397be406"},
+    {file = "grpc_stubs-1.53.0.5-py3-none-any.whl", hash = "sha256:04183fb65a1b166a1febb9627e3d9647d3926ccc2dfe049fe7b6af243428dbe1"},
+]
+
+[package.dependencies]
+grpcio = "*"
 
 [[package]]
 name = "grpcio"
@@ -762,28 +776,28 @@ validate-email = ">=1.3"
 
 [[package]]
 name = "pyasn1"
-version = "0.5.1"
+version = "0.6.0"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.5.1-py2.py3-none-any.whl", hash = "sha256:4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58"},
-    {file = "pyasn1-0.5.1.tar.gz", hash = "sha256:6d391a96e59b23130a5cfa74d6fd7f388dbbe26cc8f1edf39fdddf08d9d6676c"},
+    {file = "pyasn1-0.6.0-py2.py3-none-any.whl", hash = "sha256:cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473"},
+    {file = "pyasn1-0.6.0.tar.gz", hash = "sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c"},
 ]
 
 [[package]]
 name = "pyasn1-modules"
-version = "0.3.0"
+version = "0.4.0"
 description = "A collection of ASN.1-based protocols modules"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pyasn1_modules-0.3.0-py2.py3-none-any.whl", hash = "sha256:d3ccd6ed470d9ffbc716be08bd90efbd44d0734bc9303818f7336070984a162d"},
-    {file = "pyasn1_modules-0.3.0.tar.gz", hash = "sha256:5bd01446b736eb9d31512a30d46c1ac3395d676c6f3cafa4c03eb54b9925631c"},
+    {file = "pyasn1_modules-0.4.0-py3-none-any.whl", hash = "sha256:be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b"},
+    {file = "pyasn1_modules-0.4.0.tar.gz", hash = "sha256:831dbcea1b177b28c9baddf4c6d1013c24c3accd14a1873fffaa6a2e905f17b6"},
 ]
 
 [package.dependencies]
-pyasn1 = ">=0.4.6,<0.6.0"
+pyasn1 = ">=0.4.6,<0.7.0"
 
 [[package]]
 name = "pyflakes"
@@ -873,18 +887,18 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "setuptools"
-version = "69.2.0"
+version = "69.5.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-69.2.0-py3-none-any.whl", hash = "sha256:c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c"},
-    {file = "setuptools-69.2.0.tar.gz", hash = "sha256:0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e"},
+    {file = "setuptools-69.5.1-py3-none-any.whl", hash = "sha256:c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32"},
+    {file = "setuptools-69.5.1.tar.gz", hash = "sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -911,13 +925,13 @@ files = [
 
 [[package]]
 name = "types-protobuf"
-version = "4.24.0.20240311"
+version = "4.25.0.20240410"
 description = "Typing stubs for protobuf"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-protobuf-4.24.0.20240311.tar.gz", hash = "sha256:c80426f9fb9b21aee514691e96ab32a5cd694a82e2ac07964b352c3e7e0182bc"},
-    {file = "types_protobuf-4.24.0.20240311-py3-none-any.whl", hash = "sha256:8e039486df058141cb221ab99f88c5878c08cca4376db1d84f63279860aa09cd"},
+    {file = "types-protobuf-4.25.0.20240410.tar.gz", hash = "sha256:86576c2e7e691b8b75f4cabec430f7405edef411b5d191e847c91307935b1b38"},
+    {file = "types_protobuf-4.25.0.20240410-py3-none-any.whl", hash = "sha256:335b2e8cf9f39c233dbf0f977a2a4fbc2c0bac720225c544cc1412a67ab1e1d3"},
 ]
 
 [[package]]
@@ -975,4 +989,4 @@ test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "832a6f40905540bdfcc8c2a206fa41ab58ba20762a0b5ff1ac75bf7e994a3f8f"
+content-hash = "30c15d510c4e0f428c0fa9767487b7cf2c058f18de05fe56be6c3adaa4f33f07"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,18 @@ pyflakes = "^3.0.1"
 pytest = ">=7.1.3,<9.0.0"
 pytest-asyncio = ">=0.21,<0.24"
 protoc-gen-validate = ">=0.4.1,<=1.0.4"
+types-protobuf = "^4.25"
 
 [tool.black]
 exclude = '(^\.(.*)|^(.*)_pb2(_grpc)?\.py)'
 line-length = 100
+
+[tool.mypy]
+explicit_package_bases = true
+
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
+module = ["google.rpc.*", "grpcutil"]
 
 [tool.pytest.ini_options]
 addopts = "-x"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ typing-extensions = ">=3.7.4,<5"
 
 [tool.poetry.group.dev.dependencies]
 black = ">=23.3,<25.0"
+grpc-stubs = "^1.53"
 grpcio-tools = ">=1.59,<1.63"
 isort = "^5.6.4"
 mypy = "1.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ module = ["google.rpc.*", "grpcutil"]
 addopts = "-x"
 log_level = "debug"
 minversion = "6.0"
+asyncio_mode = "auto"
 
 [tool.isort]
 ensure_newline_before_comments = true

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -343,7 +343,7 @@ async def write_test_tuples(client):
     post_one = ObjectReference(object_type="post", object_id="post-one")
     post_two = ObjectReference(object_type="post", object_id="post-two")
     # Add some relationships.
-    resp = await maybe_await(
+    await maybe_await(
         client.WriteRelationships(
             WriteRelationshipsRequest(
                 updates=[

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -1,10 +1,10 @@
+import asyncio
 import uuid
+from inspect import isawaitable
+from typing import Any, AsyncIterable, Iterable, List, Literal, TypeVar, Union
 
 import pytest
 from google.protobuf.struct_pb2 import Struct
-import asyncio
-from typing import Literal, TypeVar, Iterable, AsyncIterable, Union, List, Any
-from inspect import isawaitable
 
 from authzed.api.v1 import (
     AsyncClient,

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -2,8 +2,12 @@ import uuid
 
 import pytest
 from google.protobuf.struct_pb2 import Struct
+import asyncio
+from typing import Literal, Any
+from dataclasses import dataclass
 
 from authzed.api.v1 import (
+    AsyncClient,
     BulkCheckPermissionRequest,
     BulkCheckPermissionRequestItem,
     BulkExportRelationshipsRequest,
@@ -20,45 +24,107 @@ from authzed.api.v1 import (
     Relationship,
     RelationshipUpdate,
     SubjectReference,
+    SyncClient,
     WriteRelationshipsRequest,
     WriteSchemaRequest,
 )
 from grpcutil import insecure_bearer_token_credentials
 
 
-@pytest.fixture(scope="function")
+# The Configuration class paramaterizes the tests in this file to run with different clients.
+# To make changes, Modify the dataclass, and the client fixture
+@dataclass
+class Configuration:
+    Client_autodetect_sync: Literal["sync", "async"] = "sync"
+    Client_autodetect_async: Literal["sync", "async"] = "async"
+    SyncClient: Literal["sync", "async"] = "sync"
+    AsyncClient: Literal["sync", "async"] = "async"
+
+
+@pytest.fixture(
+    params=Configuration().__dict__.items(),
+    ids=list(Configuration().__dict__.keys()),
+)
+def client_config(request) -> tuple[str, Literal["sync", "async"]]:
+    return request.param
+
+
+@pytest.fixture()
+def is_async(client_config: tuple[str, Literal["sync", "async"]]) -> bool:
+    return client_config[1] == "async"
+
+
+@pytest.fixture()
 def token():
     return str(uuid.uuid4())
 
 
-@pytest.fixture(scope="function")
-def client(token):
-    # NOTE: `spicedb serve-testing` must be running for these tests to work.
+@pytest.fixture()
+def client_autodetect_sync(token) -> Client:
+    with pytest.raises(RuntimeError):
+        asyncio.get_running_loop()
     return Client("localhost:50051", insecure_bearer_token_credentials(token))
 
 
-def test_basic_schema(client):
+@pytest.fixture()
+async def client_autodetect_async(token) -> Client:
+    assert asyncio.get_running_loop()
+    return Client("localhost:50051", insecure_bearer_token_credentials(token))
+
+
+@pytest.fixture()
+def sync_client(token) -> SyncClient:
+    return SyncClient("localhost:50051", insecure_bearer_token_credentials(token))
+
+
+@pytest.fixture()
+async def async_client(token) -> AsyncClient:
+    return AsyncClient("localhost:50051", insecure_bearer_token_credentials(token))
+
+
+@pytest.fixture()
+def client(
+    client_config: tuple[str, Literal["sync", "async"]],
+    client_autodetect_sync: Client,
+    client_autodetect_async: Client,
+    sync_client: SyncClient,
+    async_client: AsyncClient,
+):
+    clients = {
+        "Client_autodetect_sync": client_autodetect_sync,
+        "Client_autodetect_async": client_autodetect_async,
+        "SyncClient": sync_client,
+        "AsyncClient": async_client,
+    }
+    return clients[client_config[0]]
+
+
+async def test_basic_schema(client, is_async: bool):
     schema = """
         definition document {
             relation reader: user
         }
         definition user {}
     """
-    client.WriteSchema(WriteSchemaRequest(schema=schema))
+    resp = client.WriteSchema(WriteSchemaRequest(schema=schema))
+    if is_async:
+        await resp
 
     resp = client.ReadSchema(ReadSchemaRequest())
+    if is_async:
+        resp = await resp
     assert "definition document" in resp.schema_text
     assert "definition user" in resp.schema_text
 
 
-def test_schema_with_caveats(client):
-    write_test_schema(client)
+async def test_schema_with_caveats(client, is_async: bool):
+    await write_test_schema(client, is_async=is_async)
 
 
-def test_check(client):
+async def test_check(client, is_async: bool):
     # Write a basic schema.
-    write_test_schema(client)
-    beatrice, emilia, post_one, post_two = write_test_tuples(client)
+    await write_test_schema(client, is_async=is_async)
+    beatrice, emilia, post_one, post_two = await write_test_tuples(client, is_async=is_async)
 
     # Issue some checks.
     resp = client.CheckPermission(
@@ -69,6 +135,8 @@ def test_check(client):
             consistency=Consistency(fully_consistent=True),
         )
     )
+    if is_async:
+        resp = await resp
     assert resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
 
     resp = client.CheckPermission(
@@ -79,6 +147,8 @@ def test_check(client):
             consistency=Consistency(fully_consistent=True),
         )
     )
+    if is_async:
+        resp = await resp
     assert resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
 
     resp = client.CheckPermission(
@@ -89,6 +159,8 @@ def test_check(client):
             consistency=Consistency(fully_consistent=True),
         )
     )
+    if is_async:
+        resp = await resp
     assert resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
 
     resp = client.CheckPermission(
@@ -99,13 +171,15 @@ def test_check(client):
             consistency=Consistency(fully_consistent=True),
         )
     )
+    if is_async:
+        resp = await resp
     assert resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_NO_PERMISSION
 
 
-def test_caveated_check(client):
+async def test_caveated_check(client, is_async: bool):
     # Write a basic schema.
-    write_test_schema(client)
-    beatrice, emilia, post_one, post_two = write_test_tuples(client)
+    await write_test_schema(client, is_async=is_async)
+    beatrice, emilia, post_one, post_two = await write_test_tuples(client, is_async=is_async)
 
     s = Struct()
     # Likes Harry Potter
@@ -118,7 +192,10 @@ def test_caveated_check(client):
         consistency=Consistency(fully_consistent=True),
         context=s,
     )
+
     resp = client.CheckPermission(req)
+    if is_async:
+        resp = await resp
     assert resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
 
     # No longer likes Harry Potter
@@ -131,6 +208,8 @@ def test_caveated_check(client):
         context=s,
     )
     resp = client.CheckPermission(req)
+    if is_async:
+        resp = await resp
     assert resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_NO_PERMISSION
 
     # Fandom is in question
@@ -142,14 +221,16 @@ def test_caveated_check(client):
         context=None,
     )
     resp = client.CheckPermission(req)
+    if is_async:
+        resp = await resp
     assert resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_CONDITIONAL_PERMISSION
     assert "likes" in resp.partial_caveat_info.missing_required_context
 
 
-def test_lookup_resources(client):
+async def test_lookup_resources(client, is_async: bool):
     # Write a basic schema.
-    write_test_schema(client)
-    beatrice, emilia, post_one, post_two = write_test_tuples(client)
+    await write_test_schema(client, is_async=is_async)
+    beatrice, emilia, post_one, post_two = await write_test_tuples(client, is_async=is_async)
 
     resp = client.LookupResources(
         LookupResourcesRequest(
@@ -160,17 +241,21 @@ def test_lookup_resources(client):
         )
     )
     responses = []
-    for response in resp:
-        responses.append(response.resource_object_id)
+    if is_async:
+        async for response in resp:
+            responses.append(response.resource_object_id)
+    else:
+        for response in resp:
+            responses.append(response.resource_object_id)
     assert len(responses) == 2
     assert responses.count(post_one.object_id) == 1
     assert responses.count(post_two.object_id) == 1
 
 
-def test_lookup_subjects(client):
+async def test_lookup_subjects(client, is_async: bool):
     # Write a basic schema.
-    write_test_schema(client)
-    beatrice, emilia, post_one, post_two = write_test_tuples(client)
+    await write_test_schema(client, is_async=is_async)
+    beatrice, emilia, post_one, post_two = await write_test_tuples(client, is_async=is_async)
 
     resp = client.LookupSubjects(
         LookupSubjectsRequest(
@@ -181,17 +266,21 @@ def test_lookup_subjects(client):
         )
     )
     responses = []
-    for response in resp:
-        responses.append(response.subject_object_id)
+    if is_async:
+        async for response in resp:
+            responses.append(response.subject_object_id)
+    else:
+        for response in resp:
+            responses.append(response.subject_object_id)
     assert len(responses) == 2
     assert responses.count(emilia.object.object_id) == 1
     assert responses.count(beatrice.object.object_id) == 1
 
 
-def test_bulk_check(client):
+async def test_bulk_check(client, is_async: bool):
     # Write a basic schema.
-    write_test_schema(client)
-    beatrice, emilia, post_one, post_two = write_test_tuples(client)
+    await write_test_schema(client, is_async=is_async)
+    beatrice, emilia, post_one, post_two = await write_test_tuples(client, is_async=is_async)
 
     # Issue some checks.
     resp = client.BulkCheckPermission(
@@ -211,6 +300,8 @@ def test_bulk_check(client):
             ],
         )
     )
+    if is_async:
+        resp = await resp
 
     assert len(resp.pairs) == 2
     assert (
@@ -221,53 +312,67 @@ def test_bulk_check(client):
     )
 
 
-def test_bulk_export_import(client):
-    write_test_schema(client)
-    write_test_tuples(client)
+async def test_bulk_export_import(client, is_async: bool):
+    await write_test_schema(client, is_async=is_async)
+    await write_test_tuples(client, is_async=is_async)
 
     # validate bulk export returns all relationships written
     resp = client.BulkExportRelationships(
         BulkExportRelationshipsRequest(consistency=Consistency(fully_consistent=True))
     )
 
-    rels = rels_from_bulk_export_response(resp)
+    rels = await rels_from_bulk_export_response(resp, is_async=is_async)
     assert len(rels) == 4
 
     # create a new empty client
-    empty_client = Client("localhost:50051", insecure_bearer_token_credentials(str(uuid.uuid4())))
-    write_test_schema(empty_client)
+
+    if is_async:
+        empty_client = AsyncClient(
+            "localhost:50051", insecure_bearer_token_credentials(str(uuid.uuid4()))
+        )
+    else:
+        empty_client = SyncClient(
+            "localhost:50051", insecure_bearer_token_credentials(str(uuid.uuid4()))
+        )
+    await write_test_schema(empty_client, is_async=is_async)
 
     # validate indeed empty client is empty
     resp = empty_client.BulkExportRelationships(
         BulkExportRelationshipsRequest(consistency=Consistency(fully_consistent=True))
     )
 
-    no_rels = rels_from_bulk_export_response(resp)
+    no_rels = await rels_from_bulk_export_response(resp, is_async=is_async)
     assert len(no_rels) == 0
 
     # do bulk import
     reqs = [BulkImportRelationshipsRequest(relationships=rels)]
     import_rels = empty_client.BulkImportRelationships(((req for req in reqs)))
+    if is_async:
+        import_rels = await import_rels
     assert import_rels.num_loaded == 4
 
     # validate all relationships were imported
     resp = empty_client.BulkExportRelationships(
         BulkExportRelationshipsRequest(consistency=Consistency(fully_consistent=True))
     )
-
-    rels = rels_from_bulk_export_response(resp)
+    rels = await rels_from_bulk_export_response(resp, is_async=is_async)
     assert len(rels) == 4
 
 
-def rels_from_bulk_export_response(resp):
+async def rels_from_bulk_export_response(resp, *, is_async: bool):
     rels = []
-    for response in resp:
-        for rel in response.relationships:
-            rels.append(rel)
+    if is_async:
+        async for response in resp:
+            for rel in response.relationships:
+                rels.append(rel)
+    else:
+        for response in resp:
+            for rel in response.relationships:
+                rels.append(rel)
     return rels
 
 
-def write_test_tuples(client):
+async def write_test_tuples(client, *, is_async: bool):
     emilia = SubjectReference(
         object=ObjectReference(
             object_type="user",
@@ -283,7 +388,7 @@ def write_test_tuples(client):
     post_one = ObjectReference(object_type="post", object_id="post-one")
     post_two = ObjectReference(object_type="post", object_id="post-two")
     # Add some relationships.
-    client.WriteRelationships(
+    resp = client.WriteRelationships(
         WriteRelationshipsRequest(
             updates=[
                 # Emilia is a Writer on Post 1
@@ -326,10 +431,12 @@ def write_test_tuples(client):
             ]
         )
     )
+    if is_async:
+        resp = await resp
     return beatrice, emilia, post_one, post_two
 
 
-def write_test_schema(client):
+async def write_test_schema(client, *, is_async: bool):
     schema = """
         caveat likes_harry_potter(likes bool) {
           likes == true
@@ -346,4 +453,6 @@ def write_test_schema(client):
         }
         definition user {}
     """
-    client.WriteSchema(WriteSchemaRequest(schema=schema))
+    resp = client.WriteSchema(WriteSchemaRequest(schema=schema))
+    if is_async:
+        await resp


### PR DESCRIPTION
Fixes #140 
This adds mypy type support to the authzed library.
The code was almost there already, just needed types for the `__init__.py`

The challenge with `__init__.py` is that the Client is either sync or async depending on whether it's in an event loop. Typing this isn't really possible. So, per discord conversation, I broke out two new classes which explicitly are sync or async (and typed those appropriately)

Also, I added a new CI job to validate the types in the future


Test plan:
Made sure the py.typed file is present:
❯ tar -tf dist/authzed-0.14.0.tar.gz | grep py.typed
authzed-0.14.0/authzed/py.typed
❯ unzip -l dist/authzed-0.14.0-py3-none-any.whl | grep py.typed
        0  01-01-1980 00:00   authzed/py.typed

Made sure that mypy passes
poetry shell
mypy authzed

Made an invalid change to the __init__.pyi file and validated there was a type error
Created a CI job to ensure that the types pass as expected.

recheck