### PR TITLE
Add Insecure Client for Convenience

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,10 @@ jobs:
   pytest:
     name: "Unit and Integration Tests"
     runs-on: "ubuntu-latest"
+    services:
+      remote-spicedb:
+        image: authzed/spicedb
+        options: "--entrypoint 'spicedb serve-testing'"
     strategy:
       matrix:
         python-version:
@@ -39,9 +43,11 @@ jobs:
         with:
           version: "latest"
       - name: "Pytest"
+        # NOTE: the -m "" overrides the default marks, which
+        # selects the otherwise-unselected ci_only tests.
         run: |
           source ~/.cache/virtualenv/authzedpy/bin/activate
-          pytest -vv .
+          pytest -vv -m ""
 
   protobuf:
     name: "Generate & Diff Protobuf"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,6 @@ jobs:
   pytest:
     name: "Unit and Integration Tests"
     runs-on: "ubuntu-latest"
-    services:
-      remote-spicedb:
-        image: "authzed/spicedb"
-        options: "--entrypoint 'spicedb serve-testing'"
     strategy:
       matrix:
         python-version:
@@ -43,11 +39,9 @@ jobs:
         with:
           version: "latest"
       - name: "Pytest"
-        # NOTE: the -m "" overrides the default marks, which
-        # selects the otherwise-unselected ci_only tests.
         run: |
           source ~/.cache/virtualenv/authzedpy/bin/activate
-          pytest -vv -m ""
+          pytest -vv
 
   protobuf:
     name: "Generate & Diff Protobuf"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "ubuntu-latest"
     services:
       remote-spicedb:
-        image: authzed/spicedb
+        image: "authzed/spicedb"
         options: "--entrypoint 'spicedb serve-testing'"
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -97,3 +97,21 @@ resp = client.CheckPermission(CheckPermissionRequest(
 ))
 assert resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
 ```
+
+### Insecure Client Usage
+When running in a context like `docker compose`, because of Docker's virtual networking,
+the gRPC client sees the SpiceDB container as "remote." It has built-in safeguards to prevent
+calling a remote client in an insecure manner, such as using client credentials without TLS.
+
+However, this is a pain when setting up a development or testing environment, so we provide
+the `InsecureClient` as a convenience:
+
+```py
+from authzed.api.v1 import Client
+from grpcutil import bearer_token_credentials
+
+client = Client(
+    "spicedb:50051",
+    "my super secret token"
+)
+```

--- a/authzed/api/v1/__init__.py
+++ b/authzed/api/v1/__init__.py
@@ -191,6 +191,7 @@ __all__ = [
     "DeleteRelationshipsResponse",
     "ExpandPermissionTreeRequest",
     "ExpandPermissionTreeResponse",
+    "InsecureClient",
     "LookupResourcesRequest",
     "LookupResourcesResponse",
     "LookupSubjectsRequest",

--- a/authzed/api/v1/__init__.py
+++ b/authzed/api/v1/__init__.py
@@ -1,9 +1,8 @@
-from typing import Callable, Any
 import asyncio
+from typing import Any, Callable
 
 import grpc
 import grpc.aio
-
 from grpc_interceptor import ClientCallDetails, ClientInterceptor
 
 from authzed.api.v1.core_pb2 import (

--- a/authzed/api/v1/__init__.py
+++ b/authzed/api/v1/__init__.py
@@ -1,7 +1,10 @@
+from typing import Callable, Any
 import asyncio
 
 import grpc
 import grpc.aio
+
+from grpc_interceptor import ClientCallDetails, ClientInterceptor
 
 from authzed.api.v1.core_pb2 import (
     AlgebraicSubjectSet,
@@ -70,47 +73,95 @@ class Client(SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub,
     """
 
     def __init__(self, target, credentials, options=None, compression=None):
+        channel = self.create_channel(target, credentials, options, compression)
+        self.init_stubs(channel)
+
+    def init_stubs(self, channel):
+        SchemaServiceStub.__init__(self, channel)
+        PermissionsServiceStub.__init__(self, channel)
+        ExperimentalServiceStub.__init__(self, channel)
+        WatchServiceStub.__init__(self, channel)
+
+    def create_channel(self, target, credentials, options=None, compression=None):
         try:
             asyncio.get_running_loop()
             channelfn = grpc.aio.secure_channel
         except RuntimeError:
             channelfn = grpc.secure_channel
 
-        channel = channelfn(target, credentials, options, compression)
-        SchemaServiceStub.__init__(self, channel)
-        PermissionsServiceStub.__init__(self, channel)
-        ExperimentalServiceStub.__init__(self, channel)
-        WatchServiceStub.__init__(self, channel)
+        return channelfn(target, credentials, options, compression)
 
 
-class AsyncClient(
-    SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub, WatchServiceStub
-):
+class AsyncClient(Client):
     """
     v1 Authzed gRPC API client, for use with asyncio.
     """
 
     def __init__(self, target, credentials, options=None, compression=None):
         channel = grpc.aio.secure_channel(target, credentials, options, compression)
-        SchemaServiceStub.__init__(self, channel)
-        PermissionsServiceStub.__init__(self, channel)
-        ExperimentalServiceStub.__init__(self, channel)
-        WatchServiceStub.__init__(self, channel)
+        self.init_stubs(channel)
 
 
-class SyncClient(
-    SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub, WatchServiceStub
-):
+class SyncClient(Client):
     """
     v1 Authzed gRPC API client, running synchronously.
     """
 
     def __init__(self, target, credentials, options=None, compression=None):
         channel = grpc.secure_channel(target, credentials, options, compression)
-        SchemaServiceStub.__init__(self, channel)
-        PermissionsServiceStub.__init__(self, channel)
-        ExperimentalServiceStub.__init__(self, channel)
-        WatchServiceStub.__init__(self, channel)
+        self.init_stubs(channel)
+
+
+class TokenAuthorization(ClientInterceptor):
+    def __init__(self, token: str):
+        self._token = token
+
+    def intercept(
+        self,
+        method: Callable,
+        request_or_iterator: Any,
+        call_details: grpc.ClientCallDetails,
+    ):
+        metadata: list[tuple[str, str | bytes]] = [("authorization", f"Bearer {self._token}")]
+        if call_details.metadata is not None:
+            metadata = [*metadata, *call_details.metadata]
+
+        new_details = ClientCallDetails(
+            call_details.method,
+            call_details.timeout,
+            metadata,
+            call_details.credentials,
+            call_details.wait_for_ready,
+            call_details.compression,
+        )
+
+        return method(request_or_iterator, new_details)
+
+
+class InsecureClient(Client):
+    """
+    An insecure client variant for non-TLS contexts.
+
+    The default behavior of the python gRPC client is to restrict non-TLS
+    calls to `localhost` only, which is frustrating in contexts like docker-compose,
+    so we provide this as a convenience.
+    """
+
+    def __init__(
+        self,
+        target: str,
+        token: str,
+        options=None,
+        compression=None,
+    ):
+        fake_credentials = grpc.local_channel_credentials()
+        channel = self.create_channel(target, fake_credentials, options, compression)
+        auth_interceptor = TokenAuthorization(token)
+
+        insecure_channel = grpc.insecure_channel(target, options, compression)
+        channel = grpc.intercept_channel(insecure_channel, auth_interceptor)
+
+        self.init_stubs(channel)
 
 
 __all__ = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -310,6 +310,23 @@ protobuf = ">=3.20.2,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4
 grpc = ["grpcio (>=1.44.0,<2.0.0.dev0)"]
 
 [[package]]
+name = "grpc-interceptor"
+version = "0.15.4"
+description = "Simplifies gRPC interceptors"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "grpc-interceptor-0.15.4.tar.gz", hash = "sha256:1f45c0bcb58b6f332f37c637632247c9b02bc6af0fdceb7ba7ce8d2ebbfb0926"},
+    {file = "grpc_interceptor-0.15.4-py3-none-any.whl", hash = "sha256:0035f33228693ed3767ee49d937bac424318db173fef4d2d0170b3215f254d9d"},
+]
+
+[package.dependencies]
+grpcio = ">=1.49.1,<2.0.0"
+
+[package.extras]
+testing = ["protobuf (>=4.21.9)"]
+
+[[package]]
 name = "grpc-stubs"
 version = "1.53.0.5"
 description = "Mypy stubs for gRPC"
@@ -974,4 +991,4 @@ test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "0e8124f0ab131ff9bf9a3038fe0724c3e3aa40c1fff0b1b6f486961b45f62b2c"
+content-hash = "3b68b5ca4acef85ad82f3e10ed58fbdba3d5c75ba1a739451b1946a5d2908d97"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ grpcio = "^1.63"
 protobuf = ">=5.26,<6"
 python = "^3.8"
 typing-extensions = ">=3.7.4,<5"
+grpc-interceptor = "^0.15.4"
 
 [tool.poetry.group.dev.dependencies]
 black = ">=23.3,<25.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,13 +47,10 @@ ignore_missing_imports = true
 module = ["google.rpc.*", "grpcutil"]
 
 [tool.pytest.ini_options]
-addopts = "-x -m \"not remote_calls\""
+addopts = "-x"
 log_level = "debug"
 minversion = "6.0"
 asyncio_mode = "auto"
-markers = [
-"remote_calls: marks tests that make remote calls, not normally run"
-]
 
 [tool.isort]
 ensure_newline_before_comments = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,13 @@ ignore_missing_imports = true
 module = ["google.rpc.*", "grpcutil"]
 
 [tool.pytest.ini_options]
-addopts = "-x"
+addopts = "-x -m \"not ci_only\""
 log_level = "debug"
 minversion = "6.0"
 asyncio_mode = "auto"
+markers = [
+"ci_only: marks tests that will only run in CI"
+]
 
 [tool.isort]
 ensure_newline_before_comments = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,12 +47,12 @@ ignore_missing_imports = true
 module = ["google.rpc.*", "grpcutil"]
 
 [tool.pytest.ini_options]
-addopts = "-x -m \"not ci_only\""
+addopts = "-x -m \"not remote_calls\""
 log_level = "debug"
 minversion = "6.0"
 asyncio_mode = "auto"
 markers = [
-"ci_only: marks tests that will only run in CI"
+"remote_calls: marks tests that make remote calls, not normally run"
 ]
 
 [tool.isort]

--- a/tests/calls.py
+++ b/tests/calls.py
@@ -1,8 +1,7 @@
-from authzed.api.v1 import (
-    WriteSchemaRequest
-)
+from authzed.api.v1 import WriteSchemaRequest
 
 from .utils import maybe_await
+
 
 async def write_test_schema(client):
     schema = """

--- a/tests/calls.py
+++ b/tests/calls.py
@@ -1,0 +1,24 @@
+from authzed.api.v1 import (
+    WriteSchemaRequest
+)
+
+from .utils import maybe_await
+
+async def write_test_schema(client):
+    schema = """
+        caveat likes_harry_potter(likes bool) {
+          likes == true
+        }
+
+        definition post {
+            relation writer: user
+            relation reader: user
+            relation caveated_reader: user with likes_harry_potter
+
+            permission write = writer
+            permission view = reader + writer
+            permission view_as_fan = caveated_reader + writer
+        }
+        definition user {}
+    """
+    await maybe_await(client.WriteSchema(WriteSchemaRequest(schema=schema)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 import uuid
+
+import pytest
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import uuid
 
+
 @pytest.fixture(scope="function")
 def token():
     return str(uuid.uuid4())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+import uuid
+
+@pytest.fixture(scope="function")
+def token():
+    return str(uuid.uuid4())

--- a/tests/insecure_client_test.py
+++ b/tests/insecure_client_test.py
@@ -2,10 +2,10 @@ import pytest
 import grpc
 
 from authzed.api.v1 import (
-        InsecureClient,
-        SyncClient,
-        AsyncClient,
-        )
+    InsecureClient,
+    SyncClient,
+    AsyncClient,
+)
 from grpcutil import insecure_bearer_token_credentials
 
 from .calls import write_test_schema
@@ -18,17 +18,20 @@ from .calls import write_test_schema
 # docker run --rm -p 192.168.x.x:50051:50051 authzed/spicedb serve-testing
 remote_host = "remote-spicedb"
 
+
 @pytest.mark.ci_only
 async def test_normal_async_client_raises_error_on_insecure_remote_call(token):
     with pytest.raises(grpc.RpcError):
         client = AsyncClient(f"{remote_host}:50051", insecure_bearer_token_credentials(token))
         await write_test_schema(client)
 
+
 @pytest.mark.ci_only
 async def test_normal_sync_client_raises_error_on_insecure_remote_call(token):
     with pytest.raises(grpc.RpcError):
         client = SyncClient(f"{remote_host}:50051", insecure_bearer_token_credentials(token))
         await write_test_schema(client)
+
 
 @pytest.mark.ci_only
 async def test_insecure_client_makes_insecure_remote_call(token):

--- a/tests/insecure_client_test.py
+++ b/tests/insecure_client_test.py
@@ -1,11 +1,7 @@
-import pytest
 import grpc
+import pytest
 
-from authzed.api.v1 import (
-    InsecureClient,
-    SyncClient,
-    AsyncClient,
-)
+from authzed.api.v1 import AsyncClient, InsecureClient, SyncClient
 from grpcutil import insecure_bearer_token_credentials
 
 from .calls import write_test_schema

--- a/tests/insecure_client_test.py
+++ b/tests/insecure_client_test.py
@@ -23,6 +23,7 @@ from .calls import write_test_schema
 # docker run --rm -p 192.168.x.x:50051:50051 authzed/spicedb serve-testing
 remote_host = "192.168.something.something"
 
+
 @pytest.mark.remote_calls
 async def test_normal_async_client_raises_error_on_insecure_remote_call(token):
     with pytest.raises(grpc.RpcError):

--- a/tests/insecure_client_test.py
+++ b/tests/insecure_client_test.py
@@ -20,21 +20,21 @@ from .calls import write_test_schema
 remote_host = "192.168.something.something"
 
 
-@pytest.mark.remote_calls
+@pytest.mark.skip(reason="Makes a remote call that we haven't yet supported in CI")
 async def test_normal_async_client_raises_error_on_insecure_remote_call(token):
     with pytest.raises(grpc.RpcError):
         client = AsyncClient(f"{remote_host}:50051", insecure_bearer_token_credentials(token))
         await write_test_schema(client)
 
 
-@pytest.mark.remote_calls
+@pytest.mark.skip(reason="Makes a remote call that we haven't yet supported in CI")
 async def test_normal_sync_client_raises_error_on_insecure_remote_call(token):
     with pytest.raises(grpc.RpcError):
         client = SyncClient(f"{remote_host}:50051", insecure_bearer_token_credentials(token))
         await write_test_schema(client)
 
 
-@pytest.mark.remote_calls
+@pytest.mark.skip(reason="Makes a remote call that we haven't yet supported in CI")
 async def test_insecure_client_makes_insecure_remote_call(token):
     insecure_client = InsecureClient(f"{remote_host}:50051", token)
     await write_test_schema(insecure_client)

--- a/tests/insecure_client_test.py
+++ b/tests/insecure_client_test.py
@@ -1,0 +1,36 @@
+import pytest
+import grpc
+
+from authzed.api.v1 import (
+        InsecureClient,
+        SyncClient,
+        AsyncClient,
+        )
+from grpcutil import insecure_bearer_token_credentials
+
+from .calls import write_test_schema
+
+# NOTE: this is the name of the "remote" binding of the service container
+# in CI. These tests are only run in CI because otherwise setup is fiddly.
+# If you want to see these tests run locally, figure out your computer's
+# network-local IP address (typically 192.168.x.x) and make that the `remote_host`
+# string below, and then start up a testing container bound to that interface:
+# docker run --rm -p 192.168.x.x:50051:50051 authzed/spicedb serve-testing
+remote_host = "remote-spicedb"
+
+@pytest.mark.ci_only
+async def test_normal_async_client_raises_error_on_insecure_remote_call(token):
+    with pytest.raises(grpc.RpcError):
+        client = AsyncClient(f"{remote_host}:50051", insecure_bearer_token_credentials(token))
+        await write_test_schema(client)
+
+@pytest.mark.ci_only
+async def test_normal_sync_client_raises_error_on_insecure_remote_call(token):
+    with pytest.raises(grpc.RpcError):
+        client = SyncClient(f"{remote_host}:50051", insecure_bearer_token_credentials(token))
+        await write_test_schema(client)
+
+@pytest.mark.ci_only
+async def test_insecure_client_makes_insecure_remote_call(token):
+    insecure_client = InsecureClient(f"{remote_host}:50051", token)
+    await write_test_schema(insecure_client)

--- a/tests/insecure_client_test.py
+++ b/tests/insecure_client_test.py
@@ -10,30 +10,34 @@ from grpcutil import insecure_bearer_token_credentials
 
 from .calls import write_test_schema
 
+## NOTE: these tests aren't usually run. They theoretically could and theoretically
+# should be run in CI, but getting an appropriate "remote" container is difficult with
+# github actions; this will happen at some point in the future.
+# To run them: `poetry run pytest -m ""`
+
 # NOTE: this is the name of the "remote" binding of the service container
 # in CI. These tests are only run in CI because otherwise setup is fiddly.
 # If you want to see these tests run locally, figure out your computer's
 # network-local IP address (typically 192.168.x.x) and make that the `remote_host`
 # string below, and then start up a testing container bound to that interface:
 # docker run --rm -p 192.168.x.x:50051:50051 authzed/spicedb serve-testing
-remote_host = "remote-spicedb"
+remote_host = "192.168.something.something"
 
-
-@pytest.mark.ci_only
+@pytest.mark.remote_calls
 async def test_normal_async_client_raises_error_on_insecure_remote_call(token):
     with pytest.raises(grpc.RpcError):
         client = AsyncClient(f"{remote_host}:50051", insecure_bearer_token_credentials(token))
         await write_test_schema(client)
 
 
-@pytest.mark.ci_only
+@pytest.mark.remote_calls
 async def test_normal_sync_client_raises_error_on_insecure_remote_call(token):
     with pytest.raises(grpc.RpcError):
         client = SyncClient(f"{remote_host}:50051", insecure_bearer_token_credentials(token))
         await write_test_schema(client)
 
 
-@pytest.mark.ci_only
+@pytest.mark.remote_calls
 async def test_insecure_client_makes_insecure_remote_call(token):
     insecure_client = InsecureClient(f"{remote_host}:50051", token)
     await write_test_schema(insecure_client)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 from inspect import isawaitable
 from typing import (
     TypeVar,
+    List,
     Union,
     Iterable,
     AsyncIterable,
@@ -9,7 +10,7 @@ from typing import (
 T = TypeVar("T")
 
 
-async def maybe_async_iterable_to_list(iterable: Union[Iterable[T], AsyncIterable[T]]) -> list[T]:
+async def maybe_async_iterable_to_list(iterable: Union[Iterable[T], AsyncIterable[T]]) -> List[T]:
     items = []
     if isinstance(iterable, AsyncIterable):
         async for item in iterable:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,11 +1,5 @@
 from inspect import isawaitable
-from typing import (
-    TypeVar,
-    List,
-    Union,
-    Iterable,
-    AsyncIterable,
-)
+from typing import AsyncIterable, Iterable, List, TypeVar, Union
 
 T = TypeVar("T")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,24 @@
+from inspect import isawaitable
+from typing import (
+        TypeVar,
+        Union,
+        Iterable,
+        AsyncIterable,
+        )
+
+T = TypeVar("T")
+
+async def maybe_async_iterable_to_list(iterable: Union[Iterable[T], AsyncIterable[T]]) -> list[T]:
+    items = []
+    if isinstance(iterable, AsyncIterable):
+        async for item in iterable:
+            items.append(item)
+    else:
+        for item in iterable:
+            items.append(item)
+    return items
+
+async def maybe_await(resp: T) -> T:
+    if isawaitable(resp):
+        resp = await resp
+    return resp

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,12 +1,13 @@
 from inspect import isawaitable
 from typing import (
-        TypeVar,
-        Union,
-        Iterable,
-        AsyncIterable,
-        )
+    TypeVar,
+    Union,
+    Iterable,
+    AsyncIterable,
+)
 
 T = TypeVar("T")
+
 
 async def maybe_async_iterable_to_list(iterable: Union[Iterable[T], AsyncIterable[T]]) -> list[T]:
     items = []
@@ -17,6 +18,7 @@ async def maybe_async_iterable_to_list(iterable: Union[Iterable[T], AsyncIterabl
         for item in iterable:
             items.append(item)
     return items
+
 
 async def maybe_await(resp: T) -> T:
     if isawaitable(resp):

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -1,7 +1,6 @@
 import asyncio
 import uuid
-from inspect import isawaitable
-from typing import Any, AsyncIterable, Iterable, List, Literal, TypeVar, Union
+from typing import Any, Literal
 
 import pytest
 from google.protobuf.struct_pb2 import Struct
@@ -59,7 +58,7 @@ async def async_client(token) -> AsyncClient:
 # The configs array paramaterizes the tests in this file to run with different clients.
 # To make changes, modify both the configs array and the config fixture
 Config = Literal["Client_autodetect_sync", "Client_autodetect_async", "SyncClient", "AsyncClient"]
-configs: List[Config] = [
+configs: list[Config] = [
     "Client_autodetect_sync",
     "Client_autodetect_async",
     "SyncClient",

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -1,6 +1,6 @@
 import asyncio
 import uuid
-from typing import Any, Literal
+from typing import Any, Literal, List
 
 import pytest
 from google.protobuf.struct_pb2 import Struct
@@ -58,7 +58,7 @@ async def async_client(token) -> AsyncClient:
 # The configs array paramaterizes the tests in this file to run with different clients.
 # To make changes, modify both the configs array and the config fixture
 Config = Literal["Client_autodetect_sync", "Client_autodetect_async", "SyncClient", "AsyncClient"]
-configs: list[Config] = [
+configs: List[Config] = [
     "Client_autodetect_sync",
     "Client_autodetect_async",
     "SyncClient",

--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -1,6 +1,6 @@
 import asyncio
 import uuid
-from typing import Any, Literal, List
+from typing import Any, List, Literal
 
 import pytest
 from google.protobuf.struct_pb2 import Struct
@@ -27,9 +27,10 @@ from authzed.api.v1 import (
     WriteRelationshipsRequest,
     WriteSchemaRequest,
 )
+from grpcutil import insecure_bearer_token_credentials
+
 from .calls import write_test_schema
 from .utils import maybe_async_iterable_to_list, maybe_await
-from grpcutil import insecure_bearer_token_credentials
 
 
 @pytest.fixture()


### PR DESCRIPTION
Fixes #89 

## Description
One thing that most users of our library run into is that you can't use client credentials in a non-TLS context with the way that the Python gRPC lib is designed. This was likely intentional; network sniffing can turn into credential exposure in a production environment. However, it's frustrating and inconvenient when all you want to do is try out the lib using `docker-compose`.

This provides an `InsecureClient` that implements a workaround for those contexts.

## Changes
* Add grpc-interceptor as a dep for setting up the new interceptor
* Reorganize some code to make things more reusable
* Add an `InsecureClient` to allow for the use case
## Testing
Review. See that tests pass and that you can set up a connection with the `InsecureClient`.