### PR TITLE
Get automatic version bumping working

### DIFF
--- a/.github/workflows/automatic-api-update.yaml
+++ b/.github/workflows/automatic-api-update.yaml
@@ -22,13 +22,6 @@ jobs:
           UPDATED_STATUS: "${{ steps.buf-update.outputs.updated }}"
         run: |
           echo "Update status: $UPDATED_STATUS"
-      - name: "Update package version"
-        uses: "authzed/actions/semver-update@main"
-        if: "steps.buf-update.outputs.updated == 'true'"
-        with:
-          sourcefile-path: "pyproject.toml"
-          version-regex: 'name = "authzed"\nversion = "(.+)"'
-          version-change: "minor"
       - name: "Install buf"
         uses: "bufbuild/buf-setup-action@v1.39.0"
         with:

--- a/.github/workflows/manual-api-update.yaml
+++ b/.github/workflows/manual-api-update.yaml
@@ -26,13 +26,6 @@ jobs:
           UPDATED_STATUS: "${{ steps.buf-update.outputs.updated }}"
         run: |
           echo "Update status: $UPDATED_STATUS"
-      - name: "Update package version"
-        uses: "authzed/actions/semver-update@main"
-        if: "steps.buf-update.outputs.updated == 'true'"
-        with:
-          sourcefile-path: "pyproject.toml"
-          version-regex: 'name = "authzed"\nversion = "(.+)"'
-          version-change: "minor"
       - name: "Install buf"
         uses: "bufbuild/buf-setup-action@v1.39.0"
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,21 +1,32 @@
 ---
 name: "Publish to PyPI"
-on: "push"
+on:
+  release:
+    types:
+      - "published"
 jobs:
   publish:
     name: "Build & Publish"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v4"
+      - name: "Install Poetry"
+        uses: "snok/install-poetry@v1"
       - uses: "actions/setup-python@v5"
         with:
           python-version: "3.11"
-      - name: "Install pypa/build"
-        run: "python -m pip install build --user"
+          cache: 'poetry'
+      # This gives us a version number without the release prefix
+      - name: Write release version
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo Version: $VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: "Set the release number in pyproject.toml"
+        run: "poetry version -s $VERSION"
       - name: "Build wheel and source tarball"
-        run: "python -m build --sdist --wheel --outdir dist/ ."
+        run: "poetry build"
       - name: "Publish"
-        if: "startsWith(github.ref, 'refs/tags')"
         uses: "pypa/gh-action-pypi-publish@release/v1"
         with:
           password: "${{ secrets.PYPI_API_TOKEN }}"

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: "3.11"
           cache: 'poetry'
       # This gives us a version number without the release prefix
-      - name: Write release version
+      - name: "Write release version"
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           echo Version: $VERSION

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,10 @@
 authors = ["Authzed <support@authzed.com>"]
 description = "Client library for SpiceDB."
 
-# NOTE: These two lines must be kept together for the API update action to function
 name = "authzed"
-version = "0.18.1"
+# The version is set at publish time with a call to `poetry version -s <tag>`,
+# where the tag comes from the release.
+version = "0.0.0"
 packages = [
   {include = "authzed"},
   {include = "validate"},


### PR DESCRIPTION
## Description
A pain point in releasing this library is that you have to manually bump and commit the version prior to cutting the release. This changes the release process so that it reads the version from the tag at release time.

It also switches to using poetry as the build frontend, since we're already using it for other tasks.

## Changes
* Use poetry as build tool
* Add filter to build step
* Add version setting using poetry
* Remove version bumping from API update PR generation
* Reset pyproject.toml version and add a comment
## Testing
Review. See that a release successfully goes out (though that'll happen post-merge).