### PR TITLE
Add type annotations directly to clients

### DIFF
--- a/authzed/api/v1/__init__.pyi
+++ b/authzed/api/v1/__init__.pyi
@@ -69,53 +69,6 @@ from authzed.api.v1.schema_service_pb2_grpc import SchemaServiceAsyncStub, Schem
 from authzed.api.v1.watch_service_pb2 import WatchRequest, WatchResponse
 from authzed.api.v1.watch_service_pb2_grpc import WatchServiceAsyncStub, WatchServiceStub
 
-class Client(SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub, WatchServiceStub):
-    """The Client is typed as a synchronous client (though in practice it works with both sync and async code).
-    If you are using the async code, you should switch to the AsyncClient class instead in order to get proper type hints
-    """
-
-    def __init__(
-        self,
-        target: str,
-        credentials: grpc.ChannelCredentials,
-        options: Optional[Sequence[Tuple[str, Any]]] = None,
-        compression: Optional[grpc.Compression] = None,
-    ) -> None: ...
-
-class SyncClient(
-    SchemaServiceStub, PermissionsServiceStub, ExperimentalServiceStub, WatchServiceStub
-):
-    def __init__(
-        self,
-        target: str,
-        credentials: grpc.ChannelCredentials,
-        options: Optional[Sequence[Tuple[str, Any]]] = None,
-        compression: Optional[grpc.Compression] = None,
-    ) -> None: ...
-
-class AsyncClient(
-    SchemaServiceAsyncStub,
-    PermissionsServiceAsyncStub,
-    ExperimentalServiceAsyncStub,
-    WatchServiceAsyncStub,
-):
-    def __init__(
-        self,
-        target: str,
-        credentials: grpc.ChannelCredentials,
-        options: Optional[Sequence[Tuple[str, Any]]] = None,
-        compression: Optional[grpc.Compression] = None,
-    ) -> None: ...
-
-class InsecureClient(Client):
-    def __init__(
-        self,
-        target: str,
-        token: str,
-        options=None,
-        compression=None,
-    ) -> None: ...
-
 __all__ = [
     "Client",
     # Core


### PR DESCRIPTION
Fixes #207 

## Description
This has been a pain point a couple of times now - I make some modification to the client files and forget to make associated updates to the stub files. I figure that adding the type annotations directly to the client file should satisfy mypy and prevent me from making that mistake again.

This should be generally fine, since our targeted python versions are compatible with type annotations.

## Changes
* Add type annotations to the clients directly
## Testing
Review.