### PR TITLE
Test with Python 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: ["*"]
 env:
-  GRPC_VERSION: "1.62"
+  GRPC_VERSION: "1.67"
   BUF_VERSION: "1.30.0"
 jobs:
   pytest:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v5"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: ["*"]
 env:
-  GRPC_VERSION: "1.67"
+  GRPC_VERSION: "1.68"
   BUF_VERSION: "1.30.0"
 jobs:
   pytest:


### PR DESCRIPTION
- Poetry 1.8.4 (via poetry-core 1.9.1) automatically adds the Python 3.13 trove classifier when using `poetry build`
- https://github.com/bufbuild/protoc-gen-validate/issues/1173