### PR TITLE
Add more realistic bulk import example

### DIFF
--- a/examples/v1/bulk_check_permissions.py
+++ b/examples/v1/bulk_check_permissions.py
@@ -47,5 +47,11 @@ resp = client.BulkCheckPermission(
     )
 )
 assert len(resp.pairs) == 2
-assert resp.pairs[0].item.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
-assert resp.pairs[1].item.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
+assert (
+    resp.pairs[0].item.permissionship
+    == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
+)
+assert (
+    resp.pairs[1].item.permissionship
+    == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
+)

--- a/examples/v1/bulk_check_permissions.py
+++ b/examples/v1/bulk_check_permissions.py
@@ -47,11 +47,5 @@ resp = client.BulkCheckPermission(
     )
 )
 assert len(resp.pairs) == 2
-assert (
-    resp.pairs[0].item.permissionship
-    == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
-)
-assert (
-    resp.pairs[1].item.permissionship
-    == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
-)
+assert resp.pairs[0].item.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
+assert resp.pairs[1].item.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION

--- a/examples/v1/bulk_import_export_relationships.py
+++ b/examples/v1/bulk_import_export_relationships.py
@@ -1,3 +1,8 @@
+"""
+This demonstrates the simplest possible usage of the bulk
+import and export functionality. See import_bulk_relationships.py
+for a more realistic example of batching.
+"""
 from authzed.api.v1 import (
     BulkExportRelationshipsRequest,
     BulkImportRelationshipsRequest,
@@ -60,7 +65,7 @@ reqs = [
     )
 ]
 
-import_reps = client.BulkImportRelationships(((req for req in reqs)))
+import_reps = client.BulkImportRelationships((req for req in reqs))
 assert import_reps.num_loaded == 2
 
 export_resp = client.BulkExportRelationships(

--- a/examples/v1/bulk_import_export_relationships.py
+++ b/examples/v1/bulk_import_export_relationships.py
@@ -3,6 +3,7 @@ This demonstrates the simplest possible usage of the bulk
 import and export functionality. See import_bulk_relationships.py
 for a more realistic example of batching.
 """
+
 from authzed.api.v1 import (
     BulkExportRelationshipsRequest,
     BulkImportRelationshipsRequest,

--- a/examples/v1/import_bulk_relationships.py
+++ b/examples/v1/import_bulk_relationships.py
@@ -68,9 +68,7 @@ transaction_chunks = batched(
     relationship_generator(TOTAL_RELATIONSHIPS_TO_WRITE), RELATIONSHIPS_PER_TRANSACTION
 )
 for relationships_for_request in transaction_chunks:
-    request_chunks = batched(
-            relationships_for_request, RELATIONSHIPS_PER_REQUEST_CHUNK
-            )
+    request_chunks = batched(relationships_for_request, RELATIONSHIPS_PER_REQUEST_CHUNK)
     response = client.ImportBulkRelationships(
         (
             ImportBulkRelationshipsRequest(relationships=relationships_chunk)

--- a/examples/v1/import_bulk_relationships.py
+++ b/examples/v1/import_bulk_relationships.py
@@ -5,6 +5,7 @@ requests.
 """
 
 from itertools import batched
+
 from authzed.api.v1 import (
     Client,
     ObjectReference,

--- a/examples/v1/import_bulk_relationships.py
+++ b/examples/v1/import_bulk_relationships.py
@@ -64,15 +64,17 @@ RELATIONSHIPS_PER_REQUEST_CHUNK = 10
 # NOTE: batched takes a larger iterator and makes an iterator of smaller chunks out of it.
 # We iterate over chunks of size RELATIONSHIPS_PER_TRANSACTION, and then we break each request into
 # chunks of size RELATIONSHIPS_PER_REQUEST_CHUNK.
-for relationships_for_request in batched(
+transaction_chunks = batched(
     relationship_generator(TOTAL_RELATIONSHIPS_TO_WRITE), RELATIONSHIPS_PER_TRANSACTION
-):
+)
+for relationships_for_request in transaction_chunks:
+    request_chunks = batched(
+            relationships_for_request, RELATIONSHIPS_PER_REQUEST_CHUNK
+            )
     response = client.ImportBulkRelationships(
         (
-            ImportBulkRelationshipsRequest(relationships=relationships_for_chunk)
-            for relationships_for_chunk in batched(
-                relationships_for_request, RELATIONSHIPS_PER_REQUEST_CHUNK
-            )
+            ImportBulkRelationshipsRequest(relationships=relationships_chunk)
+            for relationships_chunk in request_chunks
         )
     )
     print("request successful")

--- a/examples/v1/import_bulk_relationships.py
+++ b/examples/v1/import_bulk_relationships.py
@@ -1,0 +1,72 @@
+"""
+This is intended to be a (slightly) more real-world example
+that demonstrates the two levels of batching in making BulkImportRelationships
+requests.
+"""
+from itertools import batched
+from authzed.api.v1 import (
+    Client,
+    ObjectReference,
+    Relationship,
+    SubjectReference,
+    WriteSchemaRequest,
+)
+from authzed.api.v1.permission_service_pb2 import ImportBulkRelationshipsRequest
+from grpcutil import insecure_bearer_token_credentials
+
+TOKEN = "sometoken"
+
+# Stand up a client
+client = Client(
+    "localhost:50051",
+    insecure_bearer_token_credentials(TOKEN),
+)
+
+# Write a simple schema
+schema = """
+    definition user {}
+    definition resource {
+        relation viewer: user
+        permission view = viewer
+    }
+"""
+
+client.WriteSchema(WriteSchemaRequest(schema=schema))
+
+# A generator that we can use to create an arbitrarily-long list of relationships
+# In your own application, this would be whatever's generating the list of imported
+# relationships.
+def relationship_generator(num_relationships):
+    idx = 0
+    while idx < num_relationships:
+        idx += 1
+        yield Relationship(
+            resource=ObjectReference(object_type="resource", object_id=str(idx)),
+            relation="viewer",
+            subject=SubjectReference(
+                object=ObjectReference(object_type="user", object_id="our_user")
+            ),
+        )
+
+
+TOTAL_RELATIONSHIPS_TO_WRITE = 1_000
+
+RELATIONSHIPS_PER_TRANSACTION = 100
+RELATIONSHIPS_PER_REQUEST_CHUNK = 10
+
+# NOTE: batched takes a larger iterator and makes an iterator of smaller chunks out of it.
+# We iterate over chunks of size RELATIONSHIPS_PER_TRANSACTION, and then we break each request into
+# chunks of size RELATIONSHIPS_PER_REQUEST_CHUNK.
+for relationships_for_request in batched(
+    relationship_generator(TOTAL_RELATIONSHIPS_TO_WRITE), RELATIONSHIPS_PER_TRANSACTION
+):
+    response = client.ImportBulkRelationships(
+        (
+            ImportBulkRelationshipsRequest(relationships=relationships_for_chunk)
+            for relationships_for_chunk in batched(
+                relationships_for_request, RELATIONSHIPS_PER_REQUEST_CHUNK
+            )
+        )
+    )
+    print("request successful")
+    print(response.num_loaded)

--- a/examples/v1/import_bulk_relationships.py
+++ b/examples/v1/import_bulk_relationships.py
@@ -2,6 +2,10 @@
 This is intended to be a (slightly) more real-world example
 that demonstrates the two levels of batching in making BulkImportRelationships
 requests.
+
+This example makes use of itertools.batched to break up an iterator of relationships
+into chunks. Documentation for itertools.batched can be found here:
+https://docs.python.org/3/library/itertools.html#itertools.batched
 """
 
 from itertools import batched

--- a/examples/v1/import_bulk_relationships.py
+++ b/examples/v1/import_bulk_relationships.py
@@ -3,6 +3,7 @@ This is intended to be a (slightly) more real-world example
 that demonstrates the two levels of batching in making BulkImportRelationships
 requests.
 """
+
 from itertools import batched
 from authzed.api.v1 import (
     Client,
@@ -32,6 +33,7 @@ schema = """
 """
 
 client.WriteSchema(WriteSchemaRequest(schema=schema))
+
 
 # A generator that we can use to create an arbitrarily-long list of relationships
 # In your own application, this would be whatever's generating the list of imported


### PR DESCRIPTION
## Description
We've gotten a couple of questions around the behavior of `ImportBulkRelationships` and how to do batching with it. This is intended as an example of a slightly-more-real-world batching strategy. I intended to use it in the documentation, but I hadn't considered that the python client speaks in terms of iterators, which is pythonic but not easily grokkable for non-python devs, so I won't use this example in the documentation, but it'll probably be helpful to have it in the examples dir.

## Changes
* Add a new example file

## Testing
Start a `serve-testing` instance and run the example against it