### PR TITLE
Remove buff generation + diffing for now

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,38 +42,3 @@ jobs:
         run: |
           source ~/.cache/virtualenv/authzedpy/bin/activate
           pytest -vv
-
-  protobuf:
-    name: "Generate & Diff Protobuf"
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: "actions/checkout@v4"
-      - uses: "actions/setup-python@v5"
-        with:
-          python-version: "3.10"
-      - name: "Setup Python Environment"
-        run: "pip install -U pip virtualenv"
-      - name: "Install Homebrew & gRPC"
-        run: |
-          bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/runner/.bash_profile
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
-          brew install grpc@$GRPC_VERSION
-          ls /home/linuxbrew/.linuxbrew/bin
-      - name: "Install Python Dependencies"
-        run: |
-          virtualenv ~/.cache/virtualenv/authzedpy
-          source ~/.cache/virtualenv/authzedpy/bin/activate
-          pip install poetry
-          poetry env info
-          poetry install --with dev
-          echo "/home/runner/.cache/virtualenv/authzedpy/bin" >> $GITHUB_PATH
-          python -V
-          whereis grpc_python_plugin
-          whereis protoc-gen-mypy
-          whereis protoc-gen-mypy_grpc
-          echo $GITHUB_PATH
-      - uses: "bufbuild/buf-setup-action@v1.39.0"
-        with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description
This step has been consistently failing for this repo because the version of gRPC we want isn't provided by `brew`. We want to move to using buf remote plugins for this anyway, so we can reimplement this when we make that change.

## Changes
* Disable step that generates and diffs protobuf

## Testing
Review. See that things go green.