### PR TITLE
Add metadata writing test

### DIFF
--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -201,6 +201,29 @@ async def test_caveated_check(client):
     assert "likes" in resp.partial_caveat_info.missing_required_context
 
 
+async def write_transaction_metadata(client):
+    response = await client.WriteRelationships(
+        WriteRelationshipsRequest(
+            updates=[
+                # Emilia is a Writer on Post 1
+                RelationshipUpdate(
+                    operation=RelationshipUpdate.Operation.OPERATION_CREATE,
+                    relationship=Relationship(
+                        resource=ObjectReference(object_type="post", object_id="1"),
+                        relation="writer",
+                        subject=SubjectReference(
+                            object=ObjectReference(object_type="user", object_id="emilia")
+                        ),
+                    ),
+                ),
+            ],
+            # We're asserting that this works.
+            optional_transaction_metadata=Struct({"foo": "bar"}),
+        )
+    )
+    assert response.written_at
+
+
 async def test_lookup_resources(client):
     # Write a basic schema.
     await write_test_schema(client)


### PR DESCRIPTION
## Description
A user reported being unable to write transaction metadata:

```python
metadata = struct_pb2.Struct()
metadata.update({"some": "metadata"})
write_relationships_request = WriteRelationshipsRequest(updates=relationship_update_requests, optional_transaction_metadata=metadata)
```

produced:

```
details = "client doesn't support type map[string]interface {}"
```

They're on an old version of the library, so this may be related to an old `protocolbuffers` version. Adding this test ensures that the same issue isn't present in current versions of the library.

## Changes
* Add a new test that writes transaction metadata
## Testing
See that things go green.