### PR TITLE
Add retryable client 

### DIFF
--- a/authzed/api/v1/__init__.py
+++ b/authzed/api/v1/__init__.py
@@ -164,8 +164,14 @@ class InsecureClient(Client):
         self.init_stubs(channel)
 
 
+# Import after defining Client to avoid circular imports
+from authzed.api.v1.retryable_client import RetryableClient, ConflictStrategy
+
+
 __all__ = [
     "Client",
+    "RetryableClient",
+    "ConflictStrategy",
     # Core
     "AlgebraicSubjectSet",
     "ContextualizedCaveat",

--- a/authzed/api/v1/retryable_client.py
+++ b/authzed/api/v1/retryable_client.py
@@ -1,0 +1,275 @@
+import asyncio
+import enum
+import time
+from typing import List, Optional
+
+import grpc
+from google.rpc import code_pb2
+from grpc import StatusCode
+
+from authzed.api.v1 import Client, Relationship, RelationshipUpdate
+from authzed.api.v1.experimental_service_pb2 import BulkImportRelationshipsRequest
+from authzed.api.v1.permission_service_pb2 import WriteRelationshipsRequest
+
+# Default configuration
+DEFAULT_BACKOFF_MS = 50
+DEFAULT_MAX_RETRIES = 10
+DEFAULT_MAX_BACKOFF_MS = 2000
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+class ConflictStrategy(enum.Enum):
+    """Strategy to handle conflicts during bulk relationship import."""
+    FAIL = 0  # The operation will fail if any duplicate relationships are found
+    SKIP = 1  # The operation will ignore duplicates and continue with the import
+    TOUCH = 2  # The operation will retry with TOUCH semantics for duplicates
+
+
+# Datastore error strings for older versions of SpiceDB
+TX_CONFLICT_STRINGS = [
+    "SQLSTATE 23505",      # CockroachDB
+    "Error 1062 (23000)",  # MySQL
+]
+
+RETRYABLE_ERROR_STRINGS = [
+    "retryable error",                          # CockroachDB, PostgreSQL
+    "try restarting transaction", "Error 1205", # MySQL
+]
+
+
+class RetryableClient(Client):
+    """
+    A client for SpiceDB that adds retryable operations with support for
+    different conflict strategies. This client extends the base Client with
+    additional functionality for handling transaction conflicts.
+    """
+
+    def __init__(self, target, credentials, options=None, compression=None):
+        super().__init__(target, credentials, options, compression)
+
+    def retryable_bulk_import_relationships(
+        self,
+        relationships: List[Relationship],
+        conflict_strategy: ConflictStrategy,
+        timeout_seconds: Optional[int] = None
+    ):
+        """
+        Import relationships with configurable retry behavior based on conflict strategy.
+        
+        Args:
+            relationships: List of relationships to import
+            conflict_strategy: Strategy to use when conflicts are detected
+            timeout_seconds: Optional timeout in seconds for the operation
+            
+        Returns:
+            The response from the successful import operation
+            
+        Raises:
+            Exception: If the import fails and cannot be retried
+        """
+        if asyncio.iscoroutinefunction(self.BulkImportRelationships):
+            return self._retryable_bulk_import_relationships_async(
+                relationships, conflict_strategy, timeout_seconds
+            )
+        else:
+            return self._retryable_bulk_import_relationships_sync(
+                relationships, conflict_strategy, timeout_seconds
+            )
+
+    def _retryable_bulk_import_relationships_sync(
+        self,
+        relationships: List[Relationship],
+        conflict_strategy: ConflictStrategy,
+        timeout_seconds: Optional[int] = None
+    ):
+        """Synchronous implementation of retryable bulk import."""
+        timeout = timeout_seconds or DEFAULT_TIMEOUT_SECONDS
+        
+        # Try bulk import first
+        writer = self.BulkImportRelationships(timeout=timeout)
+        request = BulkImportRelationshipsRequest(relationships=relationships)
+        
+        writer.send(request)
+        
+        try:
+            response = writer.done()
+            return response  # Success on first try
+        except Exception as err:
+            # Handle errors based on type and conflict strategy
+            if self._is_canceled_error(err):
+                raise err
+                
+            if self._is_already_exists_error(err) and conflict_strategy == ConflictStrategy.SKIP:
+                return None  # Skip conflicts
+                
+            if self._is_retryable_error(err) or (
+                self._is_already_exists_error(err) and 
+                conflict_strategy == ConflictStrategy.TOUCH
+            ):
+                # Retry with write_relationships_with_retry
+                return self._write_batches_with_retry_sync(relationships, timeout)
+                
+            if self._is_already_exists_error(err) and conflict_strategy == ConflictStrategy.FAIL:
+                raise ValueError("Duplicate relationships found")
+                
+            # Default case - propagate the error
+            raise ValueError(f"Error finalizing write of {len(relationships)} relationships: {err}")
+
+    async def _retryable_bulk_import_relationships_async(
+        self,
+        relationships: List[Relationship],
+        conflict_strategy: ConflictStrategy,
+        timeout_seconds: Optional[int] = None
+    ):
+        """Asynchronous implementation of retryable bulk import."""
+        timeout = timeout_seconds or DEFAULT_TIMEOUT_SECONDS
+        
+        # Try bulk import first
+        writer = await self.BulkImportRelationships(timeout=timeout)
+        request = BulkImportRelationshipsRequest(relationships=relationships)
+        
+        await writer.write(request)
+        
+        try:
+            response = await writer.done_writing()
+            return response  # Success on first try
+        except Exception as err:
+            # Handle errors based on type and conflict strategy
+            if self._is_canceled_error(err):
+                raise err
+                
+            if self._is_already_exists_error(err) and conflict_strategy == ConflictStrategy.SKIP:
+                return None  # Skip conflicts
+                
+            if self._is_retryable_error(err) or (
+                self._is_already_exists_error(err) and 
+                conflict_strategy == ConflictStrategy.TOUCH
+            ):
+                # Retry with write_relationships_with_retry
+                return await self._write_batches_with_retry_async(relationships, timeout)
+                
+            if self._is_already_exists_error(err) and conflict_strategy == ConflictStrategy.FAIL:
+                raise ValueError("Duplicate relationships found")
+                
+            # Default case - propagate the error
+            raise ValueError(f"Error finalizing write of {len(relationships)} relationships: {err}")
+
+    def _write_batches_with_retry_sync(self, relationships: List[Relationship], timeout_seconds: int):
+        """
+        Retry writing relationships in batches with exponential backoff.
+        This is a synchronous implementation.
+        """
+        updates = [
+            RelationshipUpdate(
+                relationship=rel,
+                operation=RelationshipUpdate.OPERATION_TOUCH
+            )
+            for rel in relationships
+        ]
+        
+        backoff_ms = DEFAULT_BACKOFF_MS
+        current_retries = 0
+        
+        while True:
+            try:
+                request = WriteRelationshipsRequest(updates=updates)
+                response = self.WriteRelationships(request, timeout=timeout_seconds)
+                return response
+            except Exception as err:
+                if self._is_retryable_error(err) and current_retries < DEFAULT_MAX_RETRIES:
+                    # Throttle writes with exponential backoff
+                    time.sleep(backoff_ms / 1000)
+                    backoff_ms = min(backoff_ms * 2, DEFAULT_MAX_BACKOFF_MS)
+                    current_retries += 1
+                    continue
+                
+                # Non-retryable error or max retries exceeded
+                raise ValueError(f"Failed to write relationships after retry: {err}")
+
+    async def _write_batches_with_retry_async(self, relationships: List[Relationship], timeout_seconds: int):
+        """
+        Retry writing relationships in batches with exponential backoff.
+        This is an asynchronous implementation.
+        """
+        updates = [
+            RelationshipUpdate(
+                relationship=rel,
+                operation=RelationshipUpdate.OPERATION_TOUCH
+            )
+            for rel in relationships
+        ]
+        
+        backoff_ms = DEFAULT_BACKOFF_MS
+        current_retries = 0
+        
+        while True:
+            try:
+                request = WriteRelationshipsRequest(updates=updates)
+                response = await self.WriteRelationships(request, timeout=timeout_seconds)
+                return response
+            except Exception as err:
+                if self._is_retryable_error(err) and current_retries < DEFAULT_MAX_RETRIES:
+                    # Throttle writes with exponential backoff
+                    await asyncio.sleep(backoff_ms / 1000)
+                    backoff_ms = min(backoff_ms * 2, DEFAULT_MAX_BACKOFF_MS)
+                    current_retries += 1
+                    continue
+                
+                # Non-retryable error or max retries exceeded
+                raise ValueError(f"Failed to write relationships after retry: {err}")
+
+    def _is_already_exists_error(self, err):
+        """Check if the error is an 'already exists' error."""
+        if err is None:
+            return False
+            
+        if self._is_grpc_code(err, StatusCode.ALREADY_EXISTS):
+            return True
+            
+        return self._contains_error_string(err, TX_CONFLICT_STRINGS)
+
+    def _is_retryable_error(self, err):
+        """Check if the error is retryable."""
+        if err is None:
+            return False
+            
+        if self._is_grpc_code(err, StatusCode.UNAVAILABLE, StatusCode.DEADLINE_EXCEEDED):
+            return True
+            
+        if self._contains_error_string(err, RETRYABLE_ERROR_STRINGS):
+            return True
+            
+        return isinstance(err, asyncio.TimeoutError) or isinstance(getattr(err, "__cause__", None), asyncio.TimeoutError)
+
+    def _is_canceled_error(self, err):
+        """Check if the error is a cancellation error."""
+        if err is None:
+            return False
+            
+        if isinstance(err, asyncio.CancelledError):
+            return True
+            
+        if self._is_grpc_code(err, StatusCode.CANCELLED):
+            return True
+            
+        return False
+
+    def _contains_error_string(self, err, error_strings):
+        """Check if the error message contains any of the given strings."""
+        if err is None:
+            return False
+            
+        err_str = str(err)
+        return any(es in err_str for es in error_strings)
+
+    def _is_grpc_code(self, err, *codes):
+        """Check if the error is a gRPC error with one of the given status codes."""
+        if err is None:
+            return False
+            
+        try:
+            status = grpc.StatusCode(err.code())
+            return status in codes
+        except (ValueError, AttributeError):
+            # If we can't extract a gRPC status code, it's not a gRPC error
+            return False

--- a/authzed/api/v1/retryable_client.py
+++ b/authzed/api/v1/retryable_client.py
@@ -85,14 +85,13 @@ class RetryableClient(Client):
         """Synchronous implementation of retryable bulk import."""
         timeout = timeout_seconds or DEFAULT_TIMEOUT_SECONDS
         
-        # Try bulk import first
-        writer = self.BulkImportRelationships(timeout=timeout)
-        request = BulkImportRelationshipsRequest(relationships=relationships)
+        # Create a generator function to yield requests
+        def request_iterator():
+            yield BulkImportRelationshipsRequest(relationships=relationships)
         
-        writer.send(request)
-        
+        # Try bulk import first - correctly passing the request iterator
         try:
-            response = writer.done()
+            response = self.BulkImportRelationships(request_iterator(), timeout=timeout)
             return response  # Success on first try
         except Exception as err:
             # Handle errors based on type and conflict strategy
@@ -124,14 +123,13 @@ class RetryableClient(Client):
         """Asynchronous implementation of retryable bulk import."""
         timeout = timeout_seconds or DEFAULT_TIMEOUT_SECONDS
         
-        # Try bulk import first
-        writer = await self.BulkImportRelationships(timeout=timeout)
-        request = BulkImportRelationshipsRequest(relationships=relationships)
+        # Create an async generator function to yield requests
+        async def request_iterator():
+            yield BulkImportRelationshipsRequest(relationships=relationships)
         
-        await writer.write(request)
-        
+        # Try bulk import first - correctly passing the request iterator
         try:
-            response = await writer.done_writing()
+            response = await self.BulkImportRelationships(request_iterator(), timeout=timeout)
             return response  # Success on first try
         except Exception as err:
             # Handle errors based on type and conflict strategy

--- a/examples/v1/retryable_import_relationships.py
+++ b/examples/v1/retryable_import_relationships.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from typing import List
+
+import grpc
+
+from authzed.api.v1 import (
+    ConflictStrategy,
+    ObjectReference,
+    Relationship,
+    RetryableClient,
+    SubjectReference,
+)
+
+# Environment variables for configuration
+AUTHZED_ENDPOINT = os.getenv("AUTHZED_ENDPOINT", "grpc.authzed.com:443")
+AUTHZED_TOKEN = os.getenv("AUTHZED_TOKEN", "")
+
+
+def create_sample_relationships() -> List[Relationship]:
+    """Create a list of sample relationships for import."""
+    relationships = []
+    
+    # Create 5 documents, each with view permissions for 2 users
+    for i in range(5):
+        doc_id = f"doc{i}"
+        for j in range(2):
+            user_id = f"user{j}"
+            
+            # Create a relationship where user can view document
+            rel = Relationship(
+                resource=ObjectReference(
+                    object_type="document",
+                    object_id=doc_id,
+                ),
+                relation="viewer",
+                subject=SubjectReference(
+                    object=ObjectReference(
+                        object_type="user",
+                        object_id=user_id,
+                    ),
+                ),
+            )
+            relationships.append(rel)
+    
+    return relationships
+
+
+def main():
+    """
+    Demonstrate usage of the RetryableClient for importing relationships
+    with different conflict strategies.
+    """
+    if not AUTHZED_TOKEN:
+        print("Error: AUTHZED_TOKEN environment variable is required")
+        sys.exit(1)
+    
+    # Create channel credentials
+    channel_creds = grpc.ssl_channel_credentials()
+    
+    # Create RetryableClient
+    client = RetryableClient(
+        AUTHZED_ENDPOINT,
+        grpc.composite_channel_credentials(
+            channel_creds,
+            grpc.access_token_call_credentials(AUTHZED_TOKEN),
+        ),
+    )
+    
+    # Create sample relationships
+    relationships = create_sample_relationships()
+    print(f"Created {len(relationships)} sample relationships")
+    
+    # Import relationships with TOUCH conflict strategy
+    print("Importing relationships with TOUCH conflict strategy...")
+    try:
+        client.retryable_bulk_import_relationships(
+            relationships=relationships,
+            conflict_strategy=ConflictStrategy.TOUCH,
+        )
+        print("Import successful!")
+    except Exception as e:
+        print(f"Import failed: {e}")
+    
+    # Try to import the same relationships again, but with SKIP strategy
+    print("\nImporting the same relationships again with SKIP conflict strategy...")
+    try:
+        client.retryable_bulk_import_relationships(
+            relationships=relationships,
+            conflict_strategy=ConflictStrategy.SKIP,
+        )
+        print("Import successful (skipped duplicates)!")
+    except Exception as e:
+        print(f"Import failed: {e}")
+    
+    # Try to import the same relationships again, but with FAIL strategy
+    print("\nImporting the same relationships again with FAIL conflict strategy...")
+    try:
+        client.retryable_bulk_import_relationships(
+            relationships=relationships,
+            conflict_strategy=ConflictStrategy.FAIL,
+        )
+        print("Import successful!")
+    except Exception as e:
+        print(f"Import failed as expected: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/v1/retryable_import_relationships_async.py
+++ b/examples/v1/retryable_import_relationships_async.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+import asyncio
+import os
+import sys
+from typing import List
+
+import grpc
+import grpc.aio
+
+from authzed.api.v1 import (
+    ConflictStrategy,
+    ObjectReference,
+    Relationship,
+    RetryableClient,
+    SubjectReference,
+)
+
+# Environment variables for configuration
+AUTHZED_ENDPOINT = os.getenv("AUTHZED_ENDPOINT", "grpc.authzed.com:443")
+AUTHZED_TOKEN = os.getenv("AUTHZED_TOKEN", "")
+
+
+def create_sample_relationships() -> List[Relationship]:
+    """Create a list of sample relationships for import."""
+    relationships = []
+    
+    # Create 5 documents, each with view permissions for 2 users
+    for i in range(5):
+        doc_id = f"doc{i}"
+        for j in range(2):
+            user_id = f"user{j}"
+            
+            # Create a relationship where user can view document
+            rel = Relationship(
+                resource=ObjectReference(
+                    object_type="document",
+                    object_id=doc_id,
+                ),
+                relation="viewer",
+                subject=SubjectReference(
+                    object=ObjectReference(
+                        object_type="user",
+                        object_id=user_id,
+                    ),
+                ),
+            )
+            relationships.append(rel)
+    
+    return relationships
+
+
+async def main():
+    """
+    Demonstrate usage of the RetryableClient for importing relationships
+    with different conflict strategies using async/await.
+    """
+    if not AUTHZED_TOKEN:
+        print("Error: AUTHZED_TOKEN environment variable is required")
+        sys.exit(1)
+    
+    # Create channel credentials
+    channel_creds = grpc.ssl_channel_credentials()
+    
+    # Create RetryableClient
+    client = RetryableClient(
+        AUTHZED_ENDPOINT,
+        grpc.composite_channel_credentials(
+            channel_creds,
+            grpc.access_token_call_credentials(AUTHZED_TOKEN),
+        ),
+    )
+    
+    # Create sample relationships
+    relationships = create_sample_relationships()
+    print(f"Created {len(relationships)} sample relationships")
+    
+    # Import relationships with TOUCH conflict strategy
+    print("Importing relationships with TOUCH conflict strategy...")
+    try:
+        await client.retryable_bulk_import_relationships(
+            relationships=relationships,
+            conflict_strategy=ConflictStrategy.TOUCH,
+        )
+        print("Import successful!")
+    except Exception as e:
+        print(f"Import failed: {e}")
+    
+    # Try to import the same relationships again, but with SKIP strategy
+    print("\nImporting the same relationships again with SKIP conflict strategy...")
+    try:
+        await client.retryable_bulk_import_relationships(
+            relationships=relationships,
+            conflict_strategy=ConflictStrategy.SKIP,
+        )
+        print("Import successful (skipped duplicates)!")
+    except Exception as e:
+        print(f"Import failed: {e}")
+    
+    # Try to import the same relationships again, but with FAIL strategy
+    print("\nImporting the same relationships again with FAIL conflict strategy...")
+    try:
+        await client.retryable_bulk_import_relationships(
+            relationships=relationships,
+            conflict_strategy=ConflictStrategy.FAIL,
+        )
+        print("Import successful!")
+    except Exception as e:
+        print(f"Import failed as expected: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/retryable_client_test.py
+++ b/tests/retryable_client_test.py
@@ -1,0 +1,359 @@
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import grpc
+import pytest
+from google.protobuf.empty_pb2 import Empty
+
+from authzed.api.v1 import (
+    ConflictStrategy,
+    ObjectReference,
+    Relationship,
+    RelationshipUpdate,
+    RetryableClient,
+    SubjectReference,
+    WriteRelationshipsResponse,
+)
+from authzed.api.v1.experimental_service_pb2 import BulkImportRelationshipsResponse
+from grpcutil import insecure_bearer_token_credentials
+from inspect import isawaitable
+
+
+async def maybe_await(resp):
+    """Helper function to handle both sync and async responses."""
+    if isawaitable(resp):
+        resp = await resp
+    return resp
+
+
+# Create fixtures for mocked sync and async clients
+@pytest.fixture()
+def sync_retryable_client(token) -> RetryableClient:
+    with patch.object(RetryableClient, 'create_channel') as mock_create_channel:
+        mock_channel = Mock()
+        mock_create_channel.return_value = mock_channel
+        client = RetryableClient("localhost:50051", insecure_bearer_token_credentials(token))
+        
+        # Mock all the key methods we'll use in testing
+        client.BulkImportRelationships = Mock()
+        client.WriteRelationships = Mock(return_value=WriteRelationshipsResponse())
+        
+        return client
+
+
+@pytest.fixture()
+async def async_retryable_client(token) -> RetryableClient:
+    with patch.object(RetryableClient, 'create_channel') as mock_create_channel:
+        mock_channel = Mock()
+        mock_create_channel.return_value = mock_channel
+        client = RetryableClient("localhost:50051", insecure_bearer_token_credentials(token))
+        
+        # Mock all the key methods we'll use in testing
+        client.BulkImportRelationships = AsyncMock()
+        client.WriteRelationships = AsyncMock(return_value=WriteRelationshipsResponse())
+        
+        # Force async mode
+        client._is_async = True
+        
+        return client
+
+
+@pytest.fixture(params=["sync", "async"])
+def retryable_client(
+    request,
+    sync_retryable_client: RetryableClient,
+    async_retryable_client: RetryableClient,
+):
+    clients = {
+        "sync": sync_retryable_client,
+        "async": async_retryable_client,
+    }
+    return clients[request.param]
+
+
+@pytest.fixture
+def sample_relationships():
+    """Return sample relationships for testing."""
+    return [
+        Relationship(
+            resource=ObjectReference(object_type="document", object_id="doc1"),
+            relation="viewer",
+            subject=SubjectReference(
+                object=ObjectReference(object_type="user", object_id="user1")
+            ),
+        ),
+    ]
+
+
+@patch("asyncio.iscoroutinefunction")
+async def test_successful_bulk_import(mock_is_coro, retryable_client, sample_relationships):
+    """Test that bulk import works without errors using mocks."""
+    # Configure mocks
+    mock_is_coro.return_value = isinstance(retryable_client.WriteRelationships, AsyncMock)
+    
+    if isinstance(retryable_client.BulkImportRelationships, AsyncMock):
+        # For async client
+        mock_writer = AsyncMock()
+        mock_writer.write = AsyncMock()
+        mock_writer.done_writing = AsyncMock(return_value=BulkImportRelationshipsResponse())
+        retryable_client.BulkImportRelationships.return_value = mock_writer
+    else:
+        # For sync client
+        mock_writer = Mock()
+        mock_writer.send = Mock()
+        mock_writer.done = Mock(return_value=BulkImportRelationshipsResponse())
+        retryable_client.BulkImportRelationships.return_value = mock_writer
+    
+    # Import with TOUCH conflict strategy
+    result = await maybe_await(
+        retryable_client.retryable_bulk_import_relationships(
+            relationships=sample_relationships,
+            conflict_strategy=ConflictStrategy.TOUCH,
+        )
+    )
+    
+    # Verify the expected methods were called
+    assert retryable_client.BulkImportRelationships.called
+    
+    # If we get here without errors, the test passes
+    if isinstance(retryable_client.BulkImportRelationships, AsyncMock):
+        assert mock_writer.write.called
+        assert mock_writer.done_writing.called
+    else:
+        assert mock_writer.send.called
+        assert mock_writer.done.called
+
+
+@patch("authzed.api.v1.retryable_client.RetryableClient._is_already_exists_error")
+@patch("asyncio.iscoroutinefunction")
+async def test_skip_conflict_strategy(mock_is_coro, mock_already_exists, retryable_client, sample_relationships):
+    """Test that SKIP strategy works as expected."""
+    # Configure mock behaviors
+    mock_already_exists.return_value = True
+    mock_is_coro.return_value = isinstance(retryable_client.WriteRelationships, AsyncMock)
+    
+    # Create a mock writer that raises an exception
+    mock_bulk_writer = Mock()
+    if isinstance(retryable_client.BulkImportRelationships, AsyncMock):
+        mock_bulk_writer = AsyncMock()
+        mock_bulk_writer.write = AsyncMock()
+        mock_bulk_writer.done_writing = AsyncMock(side_effect=grpc.RpcError("Already exists"))
+    else:
+        mock_bulk_writer.send = Mock()
+        mock_bulk_writer.done = Mock(side_effect=grpc.RpcError("Already exists"))
+    
+    # Set up the mock
+    retryable_client.BulkImportRelationships.return_value = mock_bulk_writer
+    
+    # Test import with SKIP conflict strategy
+    result = await maybe_await(
+        retryable_client.retryable_bulk_import_relationships(
+            relationships=sample_relationships,
+            conflict_strategy=ConflictStrategy.SKIP,
+        )
+    )
+    
+    # Should return None (indicating skipped)
+    assert result is None
+
+
+@patch("authzed.api.v1.retryable_client.RetryableClient._is_already_exists_error")
+@patch("authzed.api.v1.retryable_client.RetryableClient._write_batches_with_retry_sync")
+@patch("authzed.api.v1.retryable_client.RetryableClient._write_batches_with_retry_async")
+@patch("asyncio.iscoroutinefunction")
+async def test_touch_conflict_strategy(
+    mock_is_coro,
+    mock_write_async, 
+    mock_write_sync, 
+    mock_already_exists, 
+    retryable_client,
+    sample_relationships
+):
+    """Test that TOUCH strategy calls the correct retry method."""
+    # Configure mock behaviors
+    mock_already_exists.return_value = True
+    mock_write_sync.return_value = WriteRelationshipsResponse()
+    mock_write_async.return_value = WriteRelationshipsResponse()
+    mock_is_coro.return_value = isinstance(retryable_client.WriteRelationships, AsyncMock)
+    
+    # Create a mock writer that raises an exception
+    mock_bulk_writer = Mock()
+    if isinstance(retryable_client.BulkImportRelationships, AsyncMock):
+        mock_bulk_writer = AsyncMock()
+        mock_bulk_writer.write = AsyncMock()
+        mock_bulk_writer.done_writing = AsyncMock(side_effect=grpc.RpcError("Already exists"))
+    else:
+        mock_bulk_writer.send = Mock()
+        mock_bulk_writer.done = Mock(side_effect=grpc.RpcError("Already exists"))
+    
+    # Set up the mock
+    retryable_client.BulkImportRelationships.return_value = mock_bulk_writer
+    
+    # Test import with TOUCH conflict strategy
+    await maybe_await(
+        retryable_client.retryable_bulk_import_relationships(
+            relationships=sample_relationships,
+            conflict_strategy=ConflictStrategy.TOUCH,
+        )
+    )
+    
+    # Verify the correct retry method was called
+    if isinstance(retryable_client.BulkImportRelationships, AsyncMock):
+        assert mock_write_async.called
+        assert not mock_write_sync.called
+    else:
+        assert not mock_write_async.called
+        assert mock_write_sync.called
+
+
+@patch("authzed.api.v1.retryable_client.RetryableClient._is_already_exists_error")
+@patch("asyncio.iscoroutinefunction")
+async def test_fail_conflict_strategy(mock_is_coro, mock_already_exists, retryable_client, sample_relationships):
+    """Test that FAIL strategy raises an error when conflicts occur."""
+    # Configure mock behaviors
+    mock_already_exists.return_value = True
+    mock_is_coro.return_value = isinstance(retryable_client.WriteRelationships, AsyncMock)
+    
+    # Create a mock writer that raises an exception
+    mock_bulk_writer = Mock()
+    if isinstance(retryable_client.BulkImportRelationships, AsyncMock):
+        mock_bulk_writer = AsyncMock()
+        mock_bulk_writer.write = AsyncMock()
+        mock_bulk_writer.done_writing = AsyncMock(side_effect=grpc.RpcError("Already exists"))
+    else:
+        mock_bulk_writer.send = Mock()
+        mock_bulk_writer.done = Mock(side_effect=grpc.RpcError("Already exists"))
+    
+    # Set up the mock
+    retryable_client.BulkImportRelationships.return_value = mock_bulk_writer
+    
+    # Test import with FAIL conflict strategy
+    with pytest.raises(ValueError, match="Duplicate relationships found"):
+        await maybe_await(
+            retryable_client.retryable_bulk_import_relationships(
+                relationships=sample_relationships,
+                conflict_strategy=ConflictStrategy.FAIL,
+            )
+        )
+
+
+@patch("authzed.api.v1.retryable_client.RetryableClient._is_retryable_error")
+@patch("time.sleep")
+async def test_retry_with_backoff_sync(mock_sleep, mock_retryable, retryable_client, sample_relationships):
+    """Test retrying with exponential backoff."""
+    # Only run this test for sync client
+    if isinstance(retryable_client.WriteRelationships, AsyncMock):
+        pytest.skip("This test is for sync client only")
+        
+    # Setup for a retryable error that succeeds after 2 attempts
+    mock_retryable.side_effect = [True, True, False]
+    
+    # Create a mock that raises errors for the first two calls, then succeeds
+    mock_write = Mock()
+    mock_write.side_effect = [
+        grpc.RpcError("Retryable error"),
+        grpc.RpcError("Retryable error"),
+        WriteRelationshipsResponse(),
+    ]
+    
+    # Apply the mock
+    retryable_client.WriteRelationships = mock_write
+    
+    # Test the retry mechanism
+    result = retryable_client._write_batches_with_retry_sync(sample_relationships, 30)
+    
+    # Verify the correct number of retries occurred
+    assert mock_write.call_count == 3
+    assert mock_sleep.call_count == 2
+    
+    # Verify backoff increased
+    assert mock_sleep.call_args_list[0][0][0] < mock_sleep.call_args_list[1][0][0]
+
+
+@patch("authzed.api.v1.retryable_client.RetryableClient._is_retryable_error")
+@patch("asyncio.sleep")
+async def test_retry_with_backoff_async(mock_sleep, mock_retryable, retryable_client, sample_relationships):
+    """Test retrying with exponential backoff (async version)."""
+    # Only run this test for async client
+    if not isinstance(retryable_client.WriteRelationships, AsyncMock):
+        pytest.skip("This test is for async client only")
+        
+    # Setup for a retryable error that succeeds after 2 attempts
+    mock_retryable.side_effect = [True, True, False]
+    
+    # Create a mock that raises errors for the first two calls, then succeeds
+    mock_write = AsyncMock()
+    mock_write.side_effect = [
+        grpc.RpcError("Retryable error"),
+        grpc.RpcError("Retryable error"),
+        WriteRelationshipsResponse(),
+    ]
+    
+    # Apply the mock
+    retryable_client.WriteRelationships = mock_write
+    
+    # Test the retry mechanism
+    result = await retryable_client._write_batches_with_retry_async(sample_relationships, 30)
+    
+    # Verify the correct number of retries occurred
+    assert mock_write.call_count == 3
+    assert mock_sleep.call_count == 2
+    
+    # Verify backoff increased
+    assert mock_sleep.call_args_list[0][0][0] < mock_sleep.call_args_list[1][0][0]
+
+
+@patch("authzed.api.v1.retryable_client.RetryableClient._is_retryable_error")
+async def test_max_retries_exceeded(mock_retryable, retryable_client, sample_relationships):
+    """Test that retry count is limited."""
+    # Always report retryable error
+    mock_retryable.return_value = True
+    
+    # Create a mock that always raises errors
+    if isinstance(retryable_client.WriteRelationships, AsyncMock):
+        mock_write = AsyncMock(side_effect=grpc.RpcError("Always retryable error"))
+        retryable_client.WriteRelationships = mock_write
+        
+        # Should eventually fail after max retries
+        with pytest.raises(ValueError, match="Failed to write relationships after retry"):
+            await retryable_client._write_batches_with_retry_async(sample_relationships, 30)
+    else:
+        mock_write = Mock(side_effect=grpc.RpcError("Always retryable error"))
+        retryable_client.WriteRelationships = mock_write
+        
+        # Should eventually fail after max retries
+        with pytest.raises(ValueError, match="Failed to write relationships after retry"):
+            retryable_client._write_batches_with_retry_sync(sample_relationships, 30)
+    
+    # Verify retry count (DEFAULT_MAX_RETRIES + 1)
+    assert mock_write.call_count == 11  # 10 retries + 1 initial attempt
+
+
+def test_error_detection_methods():
+    """Test the error classification methods."""
+    client = RetryableClient("localhost:50051", insecure_bearer_token_credentials("token"))
+    
+    # Test _is_already_exists_error
+    already_exists_error = grpc.RpcError()
+    already_exists_error.code = lambda: grpc.StatusCode.ALREADY_EXISTS
+    assert client._is_already_exists_error(already_exists_error) is True
+    
+    sql_error = Exception("SQLSTATE 23505 duplicate key value violates constraint")
+    assert client._is_already_exists_error(sql_error) is True
+    
+    # Test _is_retryable_error
+    unavailable_error = grpc.RpcError()
+    unavailable_error.code = lambda: grpc.StatusCode.UNAVAILABLE
+    assert client._is_retryable_error(unavailable_error) is True
+    
+    retry_error = Exception("retryable error: restart transaction")
+    assert client._is_retryable_error(retry_error) is True
+    
+    # Test _is_canceled_error
+    canceled_error = grpc.RpcError()
+    canceled_error.code = lambda: grpc.StatusCode.CANCELLED
+    assert client._is_canceled_error(canceled_error) is True
+    
+    timeout_error = asyncio.CancelledError()
+    assert client._is_canceled_error(timeout_error) is True


### PR DESCRIPTION
This commit introduces a retryable client to authzed-py, inspired by the retry logic in authzed-go. It enhances bulk importing by automatically falling back to WriteRelationships if the bulk import operation fails.