### PR TITLE
Fix running checks on ready for review

### DIFF
--- a/.github/workflows/automatic-api-update.yaml
+++ b/.github/workflows/automatic-api-update.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Called update for API change"
-on:
+on:  # yamllint disable-line rule:truthy
   repository_dispatch:
     types: ["api_update"]
 jobs:

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,6 +1,6 @@
 ---
 name: "CLA"
-on:
+on:  # yamllint disable-line rule:truthy
   issue_comment:
     types:
       - "created"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,13 @@ on:  # yamllint disable-line rule:truthy
       - "main"
   pull_request:
     branches: ["*"]
+    types:
+      # NOTE: these are the defaults
+      - "opened"
+      - "synchronize"
+      - "reopened"
+      # NOTE: we add this to let the conversion from draft trigger the workflows
+      - "ready_for_review"
 jobs:
   lint:
     name: "Format & Lint"

--- a/.github/workflows/manual-api-update.yaml
+++ b/.github/workflows/manual-api-update.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Update for API change"
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
       buftag:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,6 @@
 ---
 name: "Publish to PyPI"
-on:
+on:  # yamllint disable-line rule:truthy
   release:
     types:
       - "published"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,13 @@ on:
       - "main"
   pull_request:
     branches: ["*"]
+    types:
+      # NOTE: these are the defaults
+      - "opened"
+      - "synchronize"
+      - "reopened"
+      # NOTE: we add this to let the conversion from draft trigger the workflows
+      - "ready_for_review"
 env:
   GRPC_VERSION: "1.68"
   BUF_VERSION: "1.30.0"


### PR DESCRIPTION
## Description
When we have the API auto-update behavior create a PR, we create it in draft so that we can trigger workflows when it moves out of draft. That requires those workflows to have that event as a trigger, similar to what's [here](https://github.com/authzed/authzed-dotnet/blob/main/.github/workflows/lint.yaml#L7-L15). This implements it for this repo.

## Changes
* Add additional triggers
## Testing
Review