### PR TITLE
Use trusted publisher configuration for pypi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,6 +8,11 @@ jobs:
   publish:
     name: "Build & Publish"
     runs-on: "ubuntu-latest"
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: "pypi"
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: "write"
     steps:
       - uses: "actions/checkout@v5"
       - uses: "astral-sh/setup-uv@v6"
@@ -23,5 +28,3 @@ jobs:
         run: "uv build"
       - name: "Publish"
         uses: "pypa/gh-action-pypi-publish@release/v1"
-        with:
-          password: "${{ secrets.PYPI_API_TOKEN }}"


### PR DESCRIPTION
## Description
This is the new recommendation for authentication for pypi. This uses OIDC between github and pypi to do the work.

See documentation here: https://docs.pypi.org/trusted-publishers/using-a-publisher/

## Changes
* Modify the action according to the documentation
## Testing
Merge this and then make another rc release and see that it works as expectd