### PR TITLE
add Materialize support to authzed-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Developers create a schema that models their permissions requirements and use a 
 
 Supported client API versions:
 
-- [v1](https://docs.authzed.com/reference/api#authzedapiv1)
+- [v1](https://docs.authzed.com/reference/api#authzedapiv1) - Core SpiceDB API for permissions checks, schema management, and relationship operations
+- [materialize/v0](https://buf.build/authzed/api/docs/main:authzed.api.materialize.v0) - Materialize API for building materialized permission views
 
 You can find more info on each API on the [Authzed API reference documentation].
 Additionally, Protobuf API documentation can be found on the [Buf Registry Authzed API repository].
@@ -114,3 +115,12 @@ client = InsecureClient(
     "my super secret token"
 )
 ```
+
+## Materialize API
+
+The authzed-py supports Authzed Materialize API.
+The Materialize API allows you to build and maintain materialized views of your permissions data in your own systems for high-performance lookups.
+
+Learn more in the **[Materialize API Quickstart Guide]** that can be found the examples directory.
+
+[Materialize API Quickstart Guide]: /examples/materialize/QUICKSTART.md

--- a/examples/materialize/QUICKSTART.md
+++ b/examples/materialize/QUICKSTART.md
@@ -1,0 +1,257 @@
+# Materialize API Quick Start
+
+The Materialize API allows you to build and maintain a materialized view of SpiceDB permissions in your own data store for high-performance lookups.
+
+## Installation
+
+```bash
+# Install authzed with UV
+uv add authzed
+
+# Or with pip
+pip install authzed
+```
+
+## Basic Usage
+
+### 1. Initial Backfill with LookupPermissionSets
+
+Use `LookupPermissionSets` to perform the initial backfill of permission sets:
+
+```python
+from authzed.api.materialize.v0 import (
+    Client,
+    LookupPermissionSetsRequest,
+)
+from grpcutil import bearer_token_credentials
+
+# Create client
+client = Client(
+    "grpc.authzed.com:443",
+    bearer_token_credentials("your_materialize_token"),
+)
+
+# Fetch permission sets
+request = LookupPermissionSetsRequest(limit=1000)
+response_stream = client.LookupPermissionSets(request)
+
+for response in response_stream:
+    change = response.change
+    parent = change.parent_set
+
+    # Store in your database
+    print(f"Parent: {parent.object_type}:{parent.object_id}#{parent.permission_or_relation}")
+
+    if change.HasField("child_member"):
+        member = change.child_member
+        print(f"  -> Member: {member.object_type}:{member.object_id}")
+```
+
+### 2. Watch for Updates with WatchPermissionSets
+
+After backfilling, watch for ongoing changes:
+
+```python
+from authzed.api.materialize.v0 import (
+    Client,
+    WatchPermissionSetsRequest,
+    PermissionSetChange,
+)
+from grpcutil import bearer_token_credentials
+
+client = Client(
+    "grpc.authzed.com:443",
+    bearer_token_credentials("your_materialize_token"),
+)
+
+request = WatchPermissionSetsRequest(
+    optional_starting_after=last_revision,  # From your last LookupPermissionSets backfill
+)
+
+response_stream = client.WatchPermissionSets(request)
+
+for response in response_stream:
+    change = response.change
+
+    # Handle the operation type
+    if change.operation == PermissionSetChange.SET_OPERATION_ADDED:
+        # Add to materialized view
+        pass
+    elif change.operation == PermissionSetChange.SET_OPERATION_REMOVED:
+        # Remove from materialized view
+        pass
+```
+
+### 3. Local Development
+
+For local Materialize instances without TLS:
+
+```python
+from authzed.api.materialize.v0 import (
+    InsecureClient,
+    LookupPermissionSetsRequest,
+)
+
+client = InsecureClient("localhost:50051", "your_local_token")
+
+request = LookupPermissionSetsRequest(limit=100)
+response_stream = client.LookupPermissionSets(request)
+
+for response in response_stream:
+    # Process responses
+    pass
+```
+
+### 4. Async Usage
+
+```python
+import asyncio
+from authzed.api.materialize.v0 import (
+    AsyncClient,
+    LookupPermissionSetsRequest,
+)
+from grpcutil import bearer_token_credentials
+
+async def fetch_permission_sets():
+    client = AsyncClient(
+        "grpc.authzed.com:443",
+        bearer_token_credentials("your_materialize_token"),
+    )
+    request = LookupPermissionSetsRequest(limit=1000)
+
+    response_stream = client.LookupPermissionSets(request)
+
+    async for response in response_stream:
+        # Process responses asynchronously
+        pass
+
+asyncio.run(fetch_permission_sets())
+```
+
+## Pagination
+
+### Synchronous Pagination
+
+Handle large datasets with cursor-based pagination:
+
+```python
+from authzed.api.materialize.v0 import (
+    Client,
+    LookupPermissionSetsRequest,
+)
+from grpcutil import bearer_token_credentials
+
+client = Client(
+    "grpc.authzed.com:443",
+    bearer_token_credentials("your_materialize_token"),
+)
+
+cursor = None
+total_processed = 0
+
+while True:
+    request = LookupPermissionSetsRequest(
+        limit=1000,
+        optional_starting_after_cursor=cursor,
+    )
+
+    count = 0
+    for response in client.LookupPermissionSets(request):
+        # Process response
+        change = response.change
+        parent = change.parent_set
+        print(f"Processed: {parent.object_type}:{parent.object_id}#{parent.permission_or_relation}")
+
+        count += 1
+        total_processed += 1
+        cursor = response.cursor if response.HasField("cursor") else None
+
+    print(f"Batch complete: {count} permission sets (total: {total_processed})")
+
+    # If we got fewer results than limit, we're done
+    if count < 1000:
+        break
+
+print(f"Pagination complete! Total: {total_processed}")
+```
+
+### Async Pagination
+
+For async/await usage with automatic pagination:
+
+```python
+import asyncio
+import grpc
+from authzed.api.materialize.v0 import (
+    AsyncClient,
+    LookupPermissionSetsRequest,
+)
+from grpcutil import bearer_token_credentials
+
+async def paginate_permission_sets():
+    client = AsyncClient(
+        "grpc.authzed.com:443",
+        bearer_token_credentials("your_materialize_token"),
+    )
+
+    cursor = None
+    total_processed = 0
+    batch_size = 1000
+
+    while True:
+        request = LookupPermissionSetsRequest(
+            limit=batch_size,
+            optional_starting_after_cursor=cursor,
+        )
+
+        count = 0
+
+        try:
+            response_stream = client.LookupPermissionSets(request)
+
+            async for response in response_stream:
+                # Process response
+                change = response.change
+                parent = change.parent_set
+                print(f"Processed: {parent.object_type}:{parent.object_id}#{parent.permission_or_relation}")
+
+                count += 1
+                total_processed += 1
+
+                # Update cursor for next batch
+                if response.HasField("cursor"):
+                    cursor = response.cursor
+
+            print(f"Batch complete: {count} permission sets (total: {total_processed})")
+
+            # If we got fewer results than limit, we're done
+            if count < batch_size:
+                break
+
+        except grpc.aio.AioRpcError as e:
+            print(f"Error: {e.code()}: {e.details()}")
+            break
+
+    print(f"Pagination complete! Total: {total_processed}")
+
+# Run the async function
+asyncio.run(paginate_permission_sets())
+```
+
+## Client Types
+
+### Overview
+
+The package provides multiple client types for different use cases:
+
+| Client | Sync/Async | Detection | Best For |
+|--------|-----------|-----------|----------|
+| `Client` | Both | Auto-detect | General use, adapts to context |
+| `SyncClient` | Sync only | Explicit | Synchronous code, better type hints |
+| `AsyncClient` | Async only | Explicit | Async code with asyncio, better type hints |
+| `InsecureClient` | Both | Auto-detect | Local dev without TLS |
+
+## Resources
+
+- [Materialize Documentation](https://authzed.com/docs/authzed/concepts/authzed-materialize)
+- [Materialize API Reference](https://buf.build/authzed/api/docs/main:authzed.api.materialize.v0)

--- a/src/authzed/api/materialize/v0/__init__.py
+++ b/src/authzed/api/materialize/v0/__init__.py
@@ -1,0 +1,159 @@
+import asyncio
+from typing import Any, Callable
+
+import grpc
+import grpc.aio
+from grpc_interceptor import ClientCallDetails, ClientInterceptor
+
+from authzed.api.materialize.v0.watchpermissions_pb2 import (
+    PermissionChange,
+    WatchedPermission,
+    WatchPermissionsRequest,
+    WatchPermissionsResponse,
+)
+from authzed.api.materialize.v0.watchpermissions_pb2_grpc import (
+    WatchPermissionsServiceStub,
+)
+from authzed.api.materialize.v0.watchpermissionsets_pb2 import (
+    BreakingSchemaChange,
+    Cursor,
+    DownloadPermissionSetsRequest,
+    DownloadPermissionSetsResponse,
+    File,
+    LookupPermissionSetsRequest,
+    LookupPermissionSetsRequired,
+    LookupPermissionSetsResponse,
+    MemberReference,
+    PermissionSetChange,
+    SetReference,
+    WatchPermissionSetsRequest,
+    WatchPermissionSetsResponse,
+)
+from authzed.api.materialize.v0.watchpermissionsets_pb2_grpc import (
+    WatchPermissionSetsServiceStub,
+)
+
+
+class Client(WatchPermissionsServiceStub, WatchPermissionSetsServiceStub):
+    """
+    v0 Materialize gRPC API client - Auto-detects sync or async depending on if initialized within an event loop
+    """
+
+    def __init__(self, target, credentials, options=None, compression=None):
+        channel = self.create_channel(target, credentials, options, compression)
+        self.init_stubs(channel)
+
+    def init_stubs(self, channel):
+        WatchPermissionsServiceStub.__init__(self, channel)
+        WatchPermissionSetsServiceStub.__init__(self, channel)
+
+    def create_channel(self, target, credentials, options=None, compression=None):
+        try:
+            asyncio.get_running_loop()
+            channelfn = grpc.aio.secure_channel
+        except RuntimeError:
+            channelfn = grpc.secure_channel
+
+        return channelfn(target, credentials, options, compression)
+
+
+class AsyncClient(Client):
+    """
+    v0 Materialize gRPC API client, for use with asyncio.
+    """
+
+    def __init__(self, target, credentials, options=None, compression=None):
+        channel = grpc.aio.secure_channel(target, credentials, options, compression)
+        self.init_stubs(channel)
+
+
+class SyncClient(Client):
+    """
+    v0 Materialize gRPC API client, running synchronously.
+    """
+
+    def __init__(self, target, credentials, options=None, compression=None):
+        channel = grpc.secure_channel(target, credentials, options, compression)
+        self.init_stubs(channel)
+
+
+class TokenAuthorization(ClientInterceptor):
+    def __init__(self, token: str):
+        self._token = token
+
+    def intercept(
+        self,
+        method: Callable,
+        request_or_iterator: Any,
+        call_details: grpc.ClientCallDetails,
+    ):
+        metadata: list[tuple[str, str | bytes]] = [("authorization", f"Bearer {self._token}")]
+        if call_details.metadata is not None:
+            metadata = [*metadata, *call_details.metadata]
+
+        new_details = ClientCallDetails(
+            call_details.method,
+            call_details.timeout,
+            metadata,
+            call_details.credentials,
+            call_details.wait_for_ready,
+            call_details.compression,
+        )
+
+        return method(request_or_iterator, new_details)
+
+
+class InsecureClient(Client):
+    """
+    An insecure client variant for non-TLS contexts.
+
+    The default behavior of the python gRPC client is to restrict non-TLS
+    calls to `localhost` only, which is frustrating in contexts like docker-compose,
+    so we provide this as a convenience.
+    """
+
+    def __init__(
+        self,
+        target: str,
+        token: str,
+        options=None,
+        compression=None,
+    ):
+        fake_credentials = grpc.local_channel_credentials()
+        channel = self.create_channel(target, fake_credentials, options, compression)
+        auth_interceptor = TokenAuthorization(token)
+
+        insecure_channel = grpc.insecure_channel(target, options, compression)
+        channel = grpc.intercept_channel(insecure_channel, auth_interceptor)
+
+        self.init_stubs(channel)
+
+
+__all__ = [
+    # Clients
+    "Client",
+    "AsyncClient",
+    "SyncClient",
+    "InsecureClient",
+    # Watch Permissions
+    "PermissionChange",
+    "WatchedPermission",
+    "WatchPermissionsRequest",
+    "WatchPermissionsResponse",
+    "WatchPermissionsServiceStub",
+    # Watch Permission Sets
+    "BreakingSchemaChange",
+    "Cursor",
+    "DownloadPermissionSetsRequest",
+    "DownloadPermissionSetsResponse",
+    "File",
+    "LookupPermissionSetsRequest",
+    "LookupPermissionSetsRequired",
+    "LookupPermissionSetsResponse",
+    "MemberReference",
+    "PermissionSetChange",
+    "SetReference",
+    "WatchPermissionSetsRequest",
+    "WatchPermissionSetsResponse",
+    "WatchPermissionSetsServiceStub",
+]

--- a/src/authzed/api/materialize/v0/__init__.pyi
+++ b/src/authzed/api/materialize/v0/__init__.pyi
@@ -1,0 +1,97 @@
+from typing import Any, Optional, Sequence, Tuple
+
+import grpc
+
+from authzed.api.materialize.v0.watchpermissions_pb2 import (
+    PermissionChange,
+    WatchedPermission,
+    WatchPermissionsRequest,
+    WatchPermissionsResponse,
+)
+from authzed.api.materialize.v0.watchpermissions_pb2_grpc import (
+    WatchPermissionsServiceStub,
+)
+from authzed.api.materialize.v0.watchpermissionsets_pb2 import (
+    BreakingSchemaChange,
+    Cursor,
+    DownloadPermissionSetsRequest,
+    DownloadPermissionSetsResponse,
+    File,
+    LookupPermissionSetsRequest,
+    LookupPermissionSetsRequired,
+    LookupPermissionSetsResponse,
+    MemberReference,
+    PermissionSetChange,
+    SetReference,
+    WatchPermissionSetsRequest,
+    WatchPermissionSetsResponse,
+)
+from authzed.api.materialize.v0.watchpermissionsets_pb2_grpc import (
+    WatchPermissionSetsServiceStub,
+)
+
+class Client(WatchPermissionsServiceStub, WatchPermissionSetsServiceStub):
+    """The Client is typed as a synchronous client (though in practice it works with both sync and async code).
+    If you are using the async code, you should switch to the AsyncClient class instead in order to get proper type hints
+    """
+
+    def __init__(
+        self,
+        target: str,
+        credentials: grpc.ChannelCredentials,
+        options: Optional[Sequence[Tuple[str, Any]]] = None,
+        compression: Optional[grpc.Compression] = None,
+    ) -> None: ...
+
+class SyncClient(WatchPermissionsServiceStub, WatchPermissionSetsServiceStub):
+    def __init__(
+        self,
+        target: str,
+        credentials: grpc.ChannelCredentials,
+        options: Optional[Sequence[Tuple[str, Any]]] = None,
+        compression: Optional[grpc.Compression] = None,
+    ) -> None: ...
+
+class AsyncClient(WatchPermissionsServiceStub, WatchPermissionSetsServiceStub):
+    def __init__(
+        self,
+        target: str,
+        credentials: grpc.ChannelCredentials,
+        options: Optional[Sequence[Tuple[str, Any]]] = None,
+        compression: Optional[grpc.Compression] = None,
+    ) -> None: ...
+
+class InsecureClient(Client):
+    def __init__(
+        self,
+        target: str,
+        token: str,
+        options=None,
+        compression=None,
+    ) -> None: ...
+
+__all__ = [
+    "Client",
+    "AsyncClient",
+    "SyncClient",
+    "InsecureClient",
+    "PermissionChange",
+    "WatchedPermission",
+    "WatchPermissionsRequest",
+    "WatchPermissionsResponse",
+    "WatchPermissionsServiceStub",
+    "BreakingSchemaChange",
+    "Cursor",
+    "DownloadPermissionSetsRequest",
+    "DownloadPermissionSetsResponse",
+    "File",
+    "LookupPermissionSetsRequest",
+    "LookupPermissionSetsRequired",
+    "LookupPermissionSetsResponse",
+    "MemberReference",
+    "PermissionSetChange",
+    "SetReference",
+    "WatchPermissionSetsRequest",
+    "WatchPermissionSetsResponse",
+    "WatchPermissionSetsServiceStub",
+]


### PR DESCRIPTION
## Description

- exposes types with `__init__` files
- adds a QUICKSTART.md file on how to use it
- updates README.md with a reference to Materialize support

## Testing

Import into another project and validate the types can be used. E.g.
```sh
 uv add --editable /Users/myuser/git/authzed-py
``` 