### PR TITLE
chore: add conventional commit linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     groups:
       pip:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -17,3 +21,7 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"

--- a/.github/workflows/automatic-api-update.yaml
+++ b/.github/workflows/automatic-api-update.yaml
@@ -39,6 +39,7 @@ jobs:
           # This is how we ensure that workflows run
           draft: "always-true"
           title: "Update API to ${{ github.event.client_payload.BUFTAG }}"
+          commit-message: "chore: update api version"
           branch: "api-change/${{ github.event.client_payload.BUFTAG }}"
           base: "main"
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -76,3 +76,11 @@ jobs:
       - uses: "astral-sh/setup-uv@v7"
       - name: "mypy"
         run: "uv run --frozen mypy src/authzed"
+
+  conventional-commits:
+    name: "Lint Commit Messages"
+    runs-on: "depot-ubuntu-24.04-small"
+    if: "github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || github.event.action == 'edited')"
+    steps:
+      - uses: "actions/checkout@v5"
+      - uses: "webiny/action-conventional-commits@v1.3.0"

--- a/.github/workflows/manual-api-update.yaml
+++ b/.github/workflows/manual-api-update.yaml
@@ -43,6 +43,7 @@ jobs:
           # This is how we ensure that workflows run
           draft: "always-true"
           title: "Update API to ${{ inputs.buftag }}"
+          commit-message: "chore: update api version"
           base: "main"
           branch: "api-change/${{ inputs.buftag }}"
           token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description
Part of preparing this repo for the use of `release-please`. We need to have conventional commits in place, so this adds a linter for that and does some other drive-by refactors to workflows.

## Changes
* Add conventional commit linting
* Make the `create-pull-request` action tag with a conventional commit (`feat` to trigger a release)
* Ensure that dependabot uses conventional commits
* Some drive-by refactors

## Testing
Review. See that tests pass.