### PR TITLE
test: fix test_write_transaction_metadata

### DIFF
--- a/tests/v1_test.py
+++ b/tests/v1_test.py
@@ -201,24 +201,29 @@ async def test_caveated_check(client):
     assert "likes" in resp.partial_caveat_info.missing_required_context
 
 
-async def write_transaction_metadata(client):
-    response = await client.WriteRelationships(
-        WriteRelationshipsRequest(
-            updates=[
-                # Emilia is a Writer on Post 1
-                RelationshipUpdate(
-                    operation=RelationshipUpdate.Operation.OPERATION_CREATE,
-                    relationship=Relationship(
-                        resource=ObjectReference(object_type="post", object_id="1"),
-                        relation="writer",
-                        subject=SubjectReference(
-                            object=ObjectReference(object_type="user", object_id="emilia")
+async def test_write_transaction_metadata(client):
+    await write_test_schema(client)
+    metadata = Struct()
+    metadata.update({"foo": "bar"})
+    response = await maybe_await(
+        client.WriteRelationships(
+            WriteRelationshipsRequest(
+                updates=[
+                    # Emilia is a Writer on Post 1
+                    RelationshipUpdate(
+                        operation=RelationshipUpdate.Operation.OPERATION_CREATE,
+                        relationship=Relationship(
+                            resource=ObjectReference(object_type="post", object_id="1"),
+                            relation="writer",
+                            subject=SubjectReference(
+                                object=ObjectReference(object_type="user", object_id="emilia")
+                            ),
                         ),
                     ),
-                ),
-            ],
-            # We're asserting that this works.
-            optional_transaction_metadata=Struct({"foo": "bar"}),
+                ],
+                # We're asserting that this works.
+                optional_transaction_metadata=metadata,
+            )
         )
     )
     assert response.written_at


### PR DESCRIPTION
## Description

Follow-up to https://github.com/authzed/authzed-py/pull/242. The test wasn't actually running.

## Test

Run locally

```
(.venv) [17:57:45] ~/Documents/GitHub/authzed-clients/authzed-py (fix-test_write_transaction_metadata) $ uv run pytest -vv .
warning: `VIRTUAL_ENV=/Users/miparnisari/Documents/GitHub/authzed-clients/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
================================================= test session starts =================================================
platform darwin -- Python 3.13.9, pytest-8.4.2, pluggy-1.5.0 -- /Users/miparnisari/Documents/GitHub/authzed-clients/authzed-py/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/miparnisari/Documents/GitHub/authzed-clients/authzed-py
configfile: pyproject.toml
plugins: asyncio-1.2.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 41 items                                                                                                    

tests/insecure_client_test.py::test_normal_async_client_raises_error_on_insecure_remote_call SKIPPED (Makes a
remote call that we haven't yet supported in CI)                                                                [  2%]
tests/insecure_client_test.py::test_normal_sync_client_raises_error_on_insecure_remote_call SKIPPED (Makes a
remote call that we haven't yet supported in CI)                                                                [  4%]
tests/insecure_client_test.py::test_insecure_client_makes_insecure_remote_call SKIPPED (Makes a remote call
that we haven't yet supported in CI)                                                                            [  7%]
tests/misc_test.py::test_type_error_does_not_segfault PASSED                                                    [  9%]
tests/misc_test.py::test_validate PASSED                                                                        [ 12%]
tests/v1_test.py::test_basic_schema[Client_autodetect_sync] PASSED                                              [ 14%]
tests/v1_test.py::test_basic_schema[Client_autodetect_async] PASSED                                             [ 17%]
tests/v1_test.py::test_basic_schema[SyncClient] PASSED                                                          [ 19%]
tests/v1_test.py::test_basic_schema[AsyncClient] PASSED                                                         [ 21%]
tests/v1_test.py::test_schema_with_caveats[Client_autodetect_sync] PASSED                                       [ 24%]
tests/v1_test.py::test_schema_with_caveats[Client_autodetect_async] PASSED                                      [ 26%]
tests/v1_test.py::test_schema_with_caveats[SyncClient] PASSED                                                   [ 29%]
tests/v1_test.py::test_schema_with_caveats[AsyncClient] PASSED                                                  [ 31%]
tests/v1_test.py::test_check[Client_autodetect_sync] PASSED                                                     [ 34%]
tests/v1_test.py::test_check[Client_autodetect_async] PASSED                                                    [ 36%]
tests/v1_test.py::test_check[SyncClient] PASSED                                                                 [ 39%]
tests/v1_test.py::test_check[AsyncClient] PASSED                                                                [ 41%]
tests/v1_test.py::test_caveated_check[Client_autodetect_sync] PASSED                                            [ 43%]
tests/v1_test.py::test_caveated_check[Client_autodetect_async] PASSED                                           [ 46%]
tests/v1_test.py::test_caveated_check[SyncClient] PASSED                                                        [ 48%]
tests/v1_test.py::test_caveated_check[AsyncClient] PASSED                                                       [ 51%]
tests/v1_test.py::test_write_transaction_metadata[Client_autodetect_sync] PASSED                                [ 53%]
tests/v1_test.py::test_write_transaction_metadata[Client_autodetect_async] PASSED                               [ 56%]
tests/v1_test.py::test_write_transaction_metadata[SyncClient] PASSED                                            [ 58%]
tests/v1_test.py::test_write_transaction_metadata[AsyncClient] PASSED                                           [ 60%]
tests/v1_test.py::test_lookup_resources[Client_autodetect_sync] PASSED                                          [ 63%]
tests/v1_test.py::test_lookup_resources[Client_autodetect_async] PASSED                                         [ 65%]
tests/v1_test.py::test_lookup_resources[SyncClient] PASSED                                                      [ 68%]
tests/v1_test.py::test_lookup_resources[AsyncClient] PASSED                                                     [ 70%]
tests/v1_test.py::test_lookup_subjects[Client_autodetect_sync] PASSED                                           [ 73%]
tests/v1_test.py::test_lookup_subjects[Client_autodetect_async] PASSED                                          [ 75%]
tests/v1_test.py::test_lookup_subjects[SyncClient] PASSED                                                       [ 78%]
tests/v1_test.py::test_lookup_subjects[AsyncClient] PASSED                                                      [ 80%]
tests/v1_test.py::test_bulk_check[Client_autodetect_sync] PASSED                                                [ 82%]
tests/v1_test.py::test_bulk_check[Client_autodetect_async] PASSED                                               [ 85%]
tests/v1_test.py::test_bulk_check[SyncClient] PASSED                                                            [ 87%]
tests/v1_test.py::test_bulk_check[AsyncClient] PASSED                                                           [ 90%]
tests/v1_test.py::test_bulk_export_import[Client_autodetect_sync] PASSED                                        [ 92%]
tests/v1_test.py::test_bulk_export_import[Client_autodetect_async] PASSED                                       [ 95%]
tests/v1_test.py::test_bulk_export_import[SyncClient] PASSED                                                    [ 97%]
tests/v1_test.py::test_bulk_export_import[AsyncClient] PASSED                                                   [100%]

================================================== warnings summary ===================================================
.venv/lib/python3.13/site-packages/lark/utils.py:163
  /Users/miparnisari/Documents/GitHub/authzed-clients/authzed-py/.venv/lib/python3.13/site-packages/lark/utils.py:163: DeprecationWarning: module 'sre_parse' is deprecated
    import sre_parse

.venv/lib/python3.13/site-packages/lark/utils.py:164
  /Users/miparnisari/Documents/GitHub/authzed-clients/authzed-py/.venv/lib/python3.13/site-packages/lark/utils.py:164: DeprecationWarning: module 'sre_constants' is deprecated
    import sre_constants

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================== 38 passed, 3 skipped, 2 warnings in 0.37s ======================================
(.venv) [17:57:50] ~/Documents/GitHub/authzed-clients/authzed-py (fix-test_write_transaction_metadata) $ 
```

see how this line got printed `tests/v1_test.py::test_write_transaction_metadata`