### PR TITLE
chore: add license key to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "authzed"
 version = "0.0.0"
 description = "Client library for SpiceDB."
+license = "Apache-2.0"
 authors = [{ name = "Authzed", email = "support@authzed.com" }]
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
## Description
This appears to be something that `uv` requires for python v3.14 builds. It's also a packaging best practice.

## Changes
* Add license entry to pyproject.toml
## Testing
Review.