### PR TITLE
feat: add grpcutil.AuthzedError to catch sync and async gRPC errors

### DIFF
--- a/src/grpcutil/__init__.py
+++ b/src/grpcutil/__init__.py
@@ -2,22 +2,16 @@ from typing import Optional
 
 import grpc
 
-
-class AuthzedError(Exception):
-    """Unified exception for both sync and async gRPC errors.
-
-    This exception wraps both grpc.RpcError (sync) and grpc.aio.AioRpcError (async)
-    to provide a consistent exception type for error handling.
-    """
-
-    def __init__(self, message: str, grpc_error: grpc.RpcError):
-        super().__init__(message)
-        self.grpc_error = grpc_error
-
-    @classmethod
-    def from_grpc_error(cls, error: grpc.RpcError) -> "AuthzedError":
-        """Create an AuthzedError from a gRPC error."""
-        return cls(str(error), error)
+# Unified exception type for catching errors from both the sync and async
+# clients. grpc.aio.AioRpcError (raised by the async client) already subclasses
+# grpc.RpcError (raised by the sync client), so a single ``except AuthzedError``
+# catches errors from either:
+#
+#     try:
+#         client.CheckPermission(...)
+#     except AuthzedError as err:
+#         ...
+AuthzedError = grpc.RpcError
 
 
 def bearer_token_credentials(token: str, certChain: Optional[bytes] = None):

--- a/src/grpcutil/__init__.py
+++ b/src/grpcutil/__init__.py
@@ -3,6 +3,23 @@ from typing import Optional
 import grpc
 
 
+class AuthzedError(Exception):
+    """Unified exception for both sync and async gRPC errors.
+
+    This exception wraps both grpc.RpcError (sync) and grpc.aio.AioRpcError (async)
+    to provide a consistent exception type for error handling.
+    """
+
+    def __init__(self, message: str, grpc_error: grpc.RpcError):
+        super().__init__(message)
+        self.grpc_error = grpc_error
+
+    @classmethod
+    def from_grpc_error(cls, error: grpc.RpcError) -> "AuthzedError":
+        """Create an AuthzedError from a gRPC error."""
+        return cls(str(error), error)
+
+
 def bearer_token_credentials(token: str, certChain: Optional[bytes] = None):
     """
     gRPC credentials for a service that requires a Bearer Token.

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -1,7 +1,20 @@
+import grpc
+import grpc.aio
 import pytest
 from protovalidate import ValidationError, validate
 
 from authzed.api.v1 import ObjectReference, Relationship
+from grpcutil import AuthzedError
+
+
+def test_authzed_error_catches_sync_and_async_grpc_errors():
+    # The sync client raises grpc.RpcError; the async client raises
+    # grpc.aio.AioRpcError. AuthzedError must catch both.
+    with pytest.raises(AuthzedError):
+        raise grpc.RpcError("sync error")
+
+    assert issubclass(grpc.RpcError, AuthzedError)
+    assert issubclass(grpc.aio.AioRpcError, AuthzedError)
 
 
 def test_type_error_does_not_segfault():


### PR DESCRIPTION
Fixes #14.

The sync client raises grpc.RpcError and the async client raises
grpc.aio.AioRpcError. This adds a single name, `grpcutil.AuthzedError`,
that catches both:

    from grpcutil import AuthzedError
    try:
        client.CheckPermission(...)
    except AuthzedError as err:
        ...

It's a thin alias for grpc.RpcError, which works because
grpc.aio.AioRpcError already subclasses grpc.RpcError - so one
`except AuthzedError` covers either client. Adds a test asserting both
error types are caught.

Note: `except grpc.RpcError` already catches both today; this just gives
the SDK a discoverable, branded name for it, as requested in the issue.